### PR TITLE
Support GTK UI on Windows, use Ubuntu Nerd Font and fix performance issue in treeview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ test_results/
 docs/_site
 docs/api
 docs/_site_pdf
+
+# IDE
+.vs/
+*.suo

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ and localization.
 
 ## Installation
 
-Install the `Material Icons` font from
-[here](https://fonts.google.com/download?family=Material+Icons).
+Install the `Ubuntu Nerd Font` font from
+[here](https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Ubuntu.zip).
 
 The project ships the application as a portable ZIP file that does not require
 any installation. Just unzip and run!

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,6 +11,7 @@
         <PackageVersion Include="Microsoft.Toolkit.Mvvm" Version="7.0.2" />
         <PackageVersion Include="Eto.Forms" Version="2.5.11" />
         <PackageVersion Include="Eto.Platform.Gtk" Version="2.5.11" />
+        <PackageVersion Include="GtkSharp.Dependencies" Version="1.1.0" />
         <PackageVersion Include="Eto.Platform.Mac64" Version="2.5.11" />
         <PackageVersion Include="Eto.Platform.Wpf" Version="2.5.11" />
         <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.818.41" />

--- a/src/SceneGate.UI.Gtk/Program.cs
+++ b/src/SceneGate.UI.Gtk/Program.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.IO;
 using Eto.Forms;
 using SceneGate.UI.Main;
 
@@ -6,9 +7,15 @@ namespace SceneGate.UI.Gtk
 {
     public static class Program
     {
-        [STAThread]
-        public static void Main(string[] args)
+        public static void Main()
         {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+                string gtkLibs = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin");
+
+                string path = Environment.GetEnvironmentVariable("Path");
+                Environment.SetEnvironmentVariable("Path", $"{gtkLibs};{path}");
+            }
+
             new Application(Eto.Platforms.Gtk).Run(new MainWindow());
         }
     }

--- a/src/SceneGate.UI.Gtk/Program.cs
+++ b/src/SceneGate.UI.Gtk/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
+using Eto.Drawing;
 using Eto.Forms;
+using Eto.GtkSharp.Forms.Controls;
 using SceneGate.UI.Main;
 
 namespace SceneGate.UI.Gtk
@@ -15,6 +17,10 @@ namespace SceneGate.UI.Gtk
                 string path = Environment.GetEnvironmentVariable("Path");
                 Environment.SetEnvironmentVariable("Path", $"{gtkLibs};{path}");
             }
+
+            Eto.Style.Add<TreeGridViewHandler>(
+                "analyze-tree",
+                handler => handler.Font = new Font("Ubuntu Nerd Font", 10));
 
             new Application(Eto.Platforms.Gtk).Run(new MainWindow());
         }

--- a/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
+++ b/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
     <SelfContained>false</SelfContained>
   </PropertyGroup>

--- a/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
+++ b/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
@@ -6,7 +6,7 @@
 
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
 
     <SelfContained>false</SelfContained>
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\SceneGate.UI\SceneGate.UI.csproj" />
 
     <PackageReference Include="Eto.Platform.Gtk" />
+    <PackageReference Include="GtkSharp.Dependencies" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
   </ItemGroup>
 
 </Project>

--- a/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
+++ b/src/SceneGate.UI.Gtk/SceneGate.UI.Gtk.csproj
@@ -7,13 +7,12 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <SelfContained>true</SelfContained>
+    <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>

--- a/src/SceneGate.UI.Wpf/Program.cs
+++ b/src/SceneGate.UI.Wpf/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Eto.Drawing;
 using Eto.Forms;
+using Eto.Wpf.Forms.Controls;
 using SceneGate.UI.Main;
 
 namespace SceneGate.UI.Wpf
@@ -7,8 +9,12 @@ namespace SceneGate.UI.Wpf
     public static class Program
     {
         [STAThread]
-        public static void Main(string[] args)
+        public static void Main()
         {
+            Eto.Style.Add<TreeGridViewHandler>(
+                "analyze-tree",
+                handler => handler.Font = new Font("Ubuntu Nerd Font", 10));
+
             new Application(Eto.Platforms.Wpf).Run(new MainWindow());
         }
     }

--- a/src/SceneGate.UI/Main/AnalyzeView.cs
+++ b/src/SceneGate.UI/Main/AnalyzeView.cs
@@ -93,16 +93,16 @@ namespace SceneGate.UI.Main
         {
             // Buttons over the treeview
             var addFileBtn = new Button {
-                Text = "\ue89c",
-                Font = new Font("Material Icons", 11),
+                Text = "\ufc50",
+                Font = new Font("Ubuntu Nerd Font", 11),
                 ToolTip = L10n.Get("Add external files"),
                 Width = 32,
                 Height = 32,
                 Command = ViewModel.AddFileCommand,
             };
             var addFolderButton = new Button {
-                Text = "\ue2cc",
-                Font = new Font("Material Icons", 11),
+                Text = "\uf756",
+                Font = new Font("Ubuntu Nerd Font", 11),
                 ToolTip = L10n.Get("Add external folders"),
                 Width = 32,
                 Height = 32,
@@ -118,6 +118,7 @@ namespace SceneGate.UI.Main
             var tree = new TreeGridView {
                 ShowHeader = false,
                 Border = BorderType.Line,
+                Style = "analyze-tree",
             };
             tree.Columns.Add(
                 new GridColumn {

--- a/src/SceneGate.UI/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Main/AnalyzeViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+﻿// Copyright (c) 2021 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -211,6 +211,7 @@ namespace SceneGate.UI.Main
                     () => Eto.Forms.MessageBox.Show(ex.ToString())).ConfigureAwait(true);
             }
 
+            node.UpdateFormatName();
             node.UpdateChildren();
             OnNodeUpdate?.Invoke(this, node);
 

--- a/src/SceneGate.UI/Main/MainWindow.cs
+++ b/src/SceneGate.UI/Main/MainWindow.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+﻿// Copyright (c) 2021 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -105,8 +105,8 @@ namespace SceneGate.UI.Main
         private Control CreateViewModeBar()
         {
             var analyzeButton = new ToggleButton {
-                Text = "\uE50A",
-                Font = new Font("Material Icons", 24),
+                Text = "\ufc84",
+                Font = new Font("Ubuntu Nerd Font", 24),
                 ToolTip = L10n.Get("Analyze"),
                 Command = viewModel.OpenAnalyzeCommand,
             };
@@ -115,8 +115,8 @@ namespace SceneGate.UI.Main
                 Binding.Property(viewModel, vm => vm.ViewKind).Convert(k => k == ViewKind.Analyze));
 
             var settingsButton = new ToggleButton {
-                Text = "\uE8B8",
-                Font = new Font("Material Icons", 24),
+                Text = "\uf992",
+                Font = new Font("Ubuntu Nerd Font", 24),
                 ToolTip = L10n.Get("Settings"),
                 Command = viewModel.OpenSettingsCommand,
             };

--- a/src/SceneGate.UI/Main/TreeGridNode.cs
+++ b/src/SceneGate.UI/Main/TreeGridNode.cs
@@ -80,11 +80,11 @@ namespace SceneGate.UI.Main
 
         public string Icon {
             get => Node.Format switch {
-                NodeContainerFormat => "\ue2c7",
-                null => "\ue2c7",
-                Po => "\uef42",
-                IBinary => "\ue24d",
-                _ => "\ue583",
+                NodeContainerFormat => "\uf74a",
+                null => "\uf74a",
+                Po => "\ufac9",
+                IBinary => "\uf471",
+                _ => "\uf779",
             };
         }
 

--- a/src/SceneGate.UI/UiPluginManager.cs
+++ b/src/SceneGate.UI/UiPluginManager.cs
@@ -39,6 +39,10 @@ namespace SceneGate.UI
             "nuget",
             "nunit",
             "testhost",
+            "Eto.",
+            "WebView",
+            "Xceed",
+            "YamlDotNet",
         };
 
         private static readonly object LockObj = new object();
@@ -108,21 +112,28 @@ namespace SceneGate.UI
         {
             // Skip libraries that match the ignored libraries because
             // MEF would try to load its dependencies.
-            return paths
+            paths = paths
                 .Select(p => new { Name = Path.GetFileName(p), Path = p })
                 .Where(p => !IgnoredLibraries.Any(
                     ign => p.Name.StartsWith(ign, StringComparison.OrdinalIgnoreCase)))
-                .Select(p => p.Path)
-                .Select(LoadAssemblies);
+                .Select(p => p.Path);
+            return LoadAssemblies(paths);
         }
 
-        private static Assembly LoadAssemblies(string path)
+        private static IEnumerable<Assembly> LoadAssemblies(IEnumerable<string> paths)
         {
-            try {
-                return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-            } catch (BadImageFormatException) {
-                // Bad IL. Skip.
-                return null;
+            foreach (string path in paths) {
+                Assembly assembly;
+                try {
+                    assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+                } catch (BadImageFormatException) {
+                    // Bad IL. Skip.
+                    assembly = null;
+                }
+
+                if (assembly is not null) {
+                    yield return assembly;
+                }
             }
         }
 


### PR DESCRIPTION
### Description

- Support the GTK-flavor of the application on Windows by deploying the native libraries. This version looks better as it's easier to add GTK themes. It deploys the _Breeze Dark_ theme by default, but users can change it from the app directory.
- Migrate from `Material Icons` font to `Ubuntu Nerd Font` from [Nerd Fonts](https://www.nerdfonts.com/). The `Material Icon` font only has icons, it doesn't have glyphs for text and the Nerd Font fixes that by patching cool fonts with thousands of icons.
  - Also apply the font to the tree view for each platform so the icons are not broken on Windows.
- Fix a performance issue in the tree view as we were reading the file stamp each time we were displaying a node.

### Example

GTK-flavor running on Windows
![image](https://user-images.githubusercontent.com/3107481/121596640-f78e9880-ca3f-11eb-8f7d-fb2998ef0f4d.png)

