### PR TITLE
✨ Simple hexadecimal viewer

### DIFF
--- a/src/SceneGate.UI.Formats/Common/HexViewModel.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewModel.cs
@@ -1,0 +1,445 @@
+﻿namespace SceneGate.UI.Formats.Common;
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Yarhl.FileFormat;
+using Yarhl.IO;
+
+/// <summary>
+/// View model for the hexadecimal view.
+/// </summary>
+public class HexViewModel : ObservableObject, IFormatViewModel
+{
+    private readonly StringBuilder textBuilder;
+    private readonly Encoding utf32BigEndian;
+    private DataStream stream;
+    private bool cursorUpdate;
+    private int maxScroll;
+    private int currentScroll;
+    private int visibleLines;
+    private string offsetsText;
+    private int hexCursorPos;
+    private string hexText;
+    private int asciiCursorPos;
+    private string asciiText;
+    private bool isBigEndian;
+    private string customEncodingName;
+    private Encoding customEncoding;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HexViewModel" /> class.
+    /// </summary>
+    public HexViewModel()
+    {
+        textBuilder = new StringBuilder();
+        DataTypes = [
+            new DataTypeItem(typeof(byte), "8-bits"),
+            new DataTypeItem(typeof(ushort), "int 16-bits"),
+            new DataTypeItem(typeof(short), "signed int 16-bits"),
+            new DataTypeItem(typeof(uint), "int 32-bits"),
+            new DataTypeItem(typeof(int), "signed int 32-bits"),
+            new DataTypeItem(typeof(ulong), "int 64-bits"),
+            new DataTypeItem(typeof(long), "signed int 64-bits"),
+            new DataTypeItem(typeof(float), "float/single 32-bits"),
+            new DataTypeItem(typeof(double), "double 64-bits"),
+            new DataTypeItem(typeof(UTF8Encoding), "UTF-8"),
+            new DataTypeItem(typeof(UnicodeEncoding), "UTF-16"),
+            new DataTypeItem(typeof(UTF32Encoding), "UTF-32"),
+            new DataTypeItem(typeof(Encoding), "Custom encoding"),
+        ];
+        utf32BigEndian = new UTF32Encoding(true, false);
+        IsBigEndian = false;
+        CustomEncodingName = "shift-jis";
+    }
+
+    /// <summary>
+    /// Notifies there was an update in the data type inspector values.
+    /// </summary>
+    public event EventHandler OnDataTypesUpdate;
+
+    /// <summary>
+    /// Gets the number of bytes per row.
+    /// </summary>
+    public int BytesPerRow => 0x10;
+
+    /// <summary>
+    /// Gets or sets the maximum scroll range.
+    /// </summary>
+    public int MaximumScroll {
+        get => maxScroll;
+        set => SetProperty(ref maxScroll, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the current scroll value.
+    /// </summary>
+    public int CurrentScroll {
+        get => currentScroll;
+        set {
+            SetProperty(ref currentScroll, value);
+            UpdateVisibleText();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the visible text rows.
+    /// </summary>
+    public int VisibleTextRows {
+        get => visibleLines;
+        set {
+            SetProperty(ref visibleLines, value);
+            AdjustScroll();
+            UpdateVisibleText();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the text for the "offset" box.
+    /// </summary>
+    public string OffsetsText {
+        get => offsetsText;
+        set => SetProperty(ref offsetsText, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the caret/cursor position of the hexadecimal view.
+    /// </summary>
+    public int HexCursorPos {
+        get => hexCursorPos;
+        set {
+            SetProperty(ref hexCursorPos, value);
+            UpdateAsciiCursor();
+            UpdateDataTypes();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the text for the hexadecimal view.
+    /// </summary>
+    public string HexText {
+        get => hexText;
+        set => SetProperty(ref hexText, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the caret/cursor position of the ASCII view.
+    /// </summary>
+    public int AsciiCursorPos {
+        get => asciiCursorPos;
+        set {
+            SetProperty(ref asciiCursorPos, value);
+            UpdateHexCursor();
+            UpdateDataTypes();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the text for the ASCII view.
+    /// </summary>
+    public string AsciiText {
+        get => asciiText;
+        set => SetProperty(ref asciiText, value);
+    }
+
+    /// <summary>
+    /// Gets the collection of items for the data type inspector.
+    /// </summary>
+    public ObservableCollection<DataTypeItem> DataTypes { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the values of the data type inspectors
+    /// show as big or little endian.
+    /// </summary>
+    public bool IsBigEndian {
+        get => isBigEndian;
+        set {
+            SetProperty(ref isBigEndian, value);
+            UpdateDataTypes();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the custom encoding for the data type inspector.
+    /// </summary>
+    public string CustomEncodingName {
+        get => customEncodingName;
+        set {
+            SetProperty(ref customEncodingName, value);
+
+            try {
+                customEncoding = Encoding.GetEncoding(
+                    value,
+                    EncoderFallback.ReplacementFallback,
+                    DecoderFallback.ReplacementFallback);
+            } catch {
+                customEncoding = null;
+            }
+
+            UpdateDataTypes();
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool CanShow(IFormat format)
+    {
+        return format is IBinary;
+    }
+
+    /// <inheritdoc/>
+    public void Show(IFormat format)
+    {
+        if (format is not IBinary binary) {
+            return;
+        }
+
+        stream = binary.Stream;
+        AdjustScroll();
+        HexCursorPos = 0;
+        UpdateVisibleText();
+    }
+
+    private void AdjustScroll()
+    {
+        // We use floor because we start at 0 so it's already one line.
+        MaximumScroll = (int)Math.Floor((float)stream.Length / BytesPerRow);
+    }
+
+    private void UpdateStreamRowPosition()
+    {
+        stream.Position = currentScroll * BytesPerRow;
+    }
+
+    private void UpdateStreamBytePosition()
+    {
+        UpdateStreamRowPosition();
+        int hexCharsPerLine = BytesPerRow * 3;
+        int y = HexCursorPos / hexCharsPerLine;
+        int x = (HexCursorPos % hexCharsPerLine) / 3;
+
+        int position = x + (y * BytesPerRow);
+        if (stream.Position + position < stream.Length) {
+            stream.Position += position;
+        } else {
+            stream.Position = stream.Length;
+        }
+    }
+
+    private void UpdateVisibleText()
+    {
+        UpdateDataTypes();
+
+        UpdateStreamRowPosition();
+        long startPosition = stream.Position;
+
+        int numBytes = BytesPerRow * VisibleTextRows;
+        byte[] buffer = new byte[numBytes];
+        int read = stream.Read(buffer);
+
+        textBuilder.Clear();
+        for (int i = 0; i < read; i += BytesPerRow) {
+            textBuilder.AppendFormat("{0:X8}\n", startPosition + i);
+        }
+
+        OffsetsText = textBuilder.ToString();
+
+        textBuilder.Clear();
+        for (int i = 0; i < read; i++) {
+            if (i + 1 == read) {
+                textBuilder.AppendFormat("{0:X2}", buffer[i]);
+            } else if (i != 0 && ((i + 1) % BytesPerRow == 0)) {
+                textBuilder.AppendFormat("{0:X2}\n", buffer[i]);
+            } else {
+                textBuilder.AppendFormat("{0:X2} ", buffer[i]);
+            }
+        }
+
+        HexText = textBuilder.ToString();
+
+        textBuilder.Clear();
+        for (int i = 0; i < read; i++) {
+            char ch = (buffer[i] >= 0x21 && buffer[i] <= 0x7F) ? (char)buffer[i] : '.';
+            if (i + 1 == read) {
+                textBuilder.Append(ch);
+            } else if (i != 0 && ((i + 1) % BytesPerRow == 0)) {
+                textBuilder.AppendFormat("{0}\n", ch);
+            } else {
+                textBuilder.AppendFormat("{0} ", ch);
+            }
+        }
+
+        AsciiText = textBuilder.ToString();
+    }
+
+    private void UpdateAsciiCursor()
+    {
+        if (cursorUpdate) {
+            return;
+        }
+
+        cursorUpdate = true;
+
+        int hexCharsPerLine = BytesPerRow * 3;
+        int asciiCharsPerLine = BytesPerRow * 2;
+        int y = HexCursorPos / hexCharsPerLine;
+        int x = (HexCursorPos % hexCharsPerLine) / 3;
+        AsciiCursorPos = (x * 2) + (y * asciiCharsPerLine);
+
+        cursorUpdate = false;
+    }
+
+    private void UpdateHexCursor()
+    {
+        if (cursorUpdate) {
+            return;
+        }
+
+        cursorUpdate = true;
+
+        int hexCharsPerLine = BytesPerRow * 3;
+        int asciiCharsPerLine = BytesPerRow * 2;
+        int y = AsciiCursorPos / asciiCharsPerLine;
+        int x = (AsciiCursorPos % asciiCharsPerLine) / 2;
+        HexCursorPos = (x * 3) + (y * hexCharsPerLine);
+
+        cursorUpdate = false;
+    }
+
+    private void UpdateDataTypes()
+    {
+        if (stream is null || stream.Disposed) {
+            return;
+        }
+
+        UpdateStreamBytePosition();
+        ClearTypeValues();
+
+        byte[] buffer = new byte[16];
+        int read = stream.Read(buffer, 0, buffer.Length);
+        stream.Position -= read;
+        if (read == 0) {
+            OnDataTypesUpdate?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        ulong value = IsBigEndian
+            ? BinaryPrimitives.ReadUInt64BigEndian(buffer)
+            : BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+
+        int numBits = 8;
+        if (read >= 2) {
+            numBits = 16;
+            ushort bits16 = IsBigEndian ? (ushort)(value >> (64 - 16)) : (ushort)value;
+            UpdateTypeValue<ushort>(bits16.ToString(CultureInfo.CurrentCulture));
+            UpdateTypeValue<short>(((short)bits16).ToString(CultureInfo.CurrentCulture));
+        }
+
+        if (read >= 4) {
+            numBits = 32;
+            uint bits32 = IsBigEndian ? (uint)(value >> (64 - 32)) : (uint)value;
+            UpdateTypeValue<uint>(bits32.ToString(CultureInfo.CurrentCulture));
+            UpdateTypeValue<int>(((int)bits32).ToString(CultureInfo.CurrentCulture));
+
+            float floatValue = IsBigEndian
+                ? BinaryPrimitives.ReadSingleBigEndian(buffer)
+                : BinaryPrimitives.ReadSingleLittleEndian(buffer);
+            UpdateTypeValue<float>(floatValue.ToString(CultureInfo.CurrentCulture));
+        }
+
+        if (read >= 8) {
+            UpdateTypeValue<ulong>(value.ToString(CultureInfo.CurrentCulture));
+            UpdateTypeValue<long>(((long)value).ToString(CultureInfo.CurrentCulture));
+
+            double doubleValue = IsBigEndian
+                ? BinaryPrimitives.ReadDoubleBigEndian(buffer)
+                : BinaryPrimitives.ReadDoubleLittleEndian(buffer);
+            UpdateTypeValue<double>(doubleValue.ToString(CultureInfo.CurrentCulture));
+        }
+
+        // We want to start from MSB (high) so LSB is on the right.
+        textBuilder.Clear();
+        uint bitValue = IsBigEndian ? (uint)(value >> (64 - numBits)) : (uint)value;
+        for (int i = numBits - 1; i >= 0; i--) {
+            textBuilder.Append((bitValue & (1u << i)) == 0 ? "0" : "1");
+            if (i != 0 && (i % 8) == 0) {
+                textBuilder.Append(' ');
+            }
+        }
+
+        UpdateTypeValue<byte>(textBuilder.ToString());
+
+        UpdateTypeValue<UTF8Encoding>(Regex.Escape(Encoding.UTF8.GetString(buffer)));
+
+        var utf16 = IsBigEndian ? Encoding.BigEndianUnicode : Encoding.Unicode;
+        UpdateTypeValue<UnicodeEncoding>(Regex.Escape(utf16.GetString(buffer)));
+
+        var utf32 = IsBigEndian ? Encoding.UTF32 : utf32BigEndian;
+        UpdateTypeValue<UTF32Encoding>(Regex.Escape(utf32.GetString(buffer)));
+
+        if (customEncoding is not null) {
+            UpdateTypeValue<Encoding>(Regex.Escape(customEncoding.GetString(buffer)));
+        } else {
+            UpdateTypeValue<Encoding>("Unknown encoding name");
+        }
+
+        // GridView doesn't implement MVVM binding.
+        // https://github.com/picoe/Eto/issues/530
+        OnDataTypesUpdate?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void UpdateTypeValue<T>(string value)
+    {
+        var type = typeof(T);
+        DataTypes.First(i => i.Type == type).Value = value;
+    }
+
+    private void ClearTypeValues()
+    {
+        foreach (var item in DataTypes) {
+            item.Value = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Item of the data type inspector.
+    /// </summary>
+    public class DataTypeItem : ObservableObject
+    {
+        private string dataValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataTypeItem" /> class.
+        /// </summary>
+        /// <param name="type">The type to represent.</param>
+        /// <param name="description">The description of the type.</param>
+        public DataTypeItem(Type type, string description)
+        {
+            Type = type;
+            Description = description;
+            Value = string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the type of the item.
+        /// </summary>
+        public Type Type { get; }
+
+        /// <summary>
+        /// Gets the description of the type.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Gets or sets the value for this type instance.
+        /// </summary>
+        public string Value {
+            get => dataValue;
+            set => SetProperty(ref dataValue, value);
+        }
+    }
+}

--- a/src/SceneGate.UI.Formats/Common/HexViewerView.axaml
+++ b/src/SceneGate.UI.Formats/Common/HexViewerView.axaml
@@ -1,0 +1,81 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="using:SceneGate.UI.Formats.Common"
+             mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="600"
+             x:Class="SceneGate.UI.Formats.Common.HexViewerView"
+             x:DataType="local:HexViewerViewModel">
+  <Design.DataContext>
+    <local:HexViewerViewModel />
+  </Design.DataContext>
+
+  <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,*"
+        RowDefinitions="Auto,*">
+
+    <TextBox Grid.Row="0" Grid.Column="1"
+             Text="{Binding PositionText}"
+             IsReadOnly="True"
+             Background="Transparent"
+             BorderThickness="0"
+             VerticalContentAlignment="Center"
+             FontSize="13"
+             FontFamily="{StaticResource CaskaydiaFont}" />
+
+    <TextBox Grid.Row="1" Grid.Column="0"
+             Text="{Binding OffsetsText}"
+             IsReadOnly="True"
+             Background="Transparent"
+             FontSize="13"
+             FontFamily="{StaticResource CaskaydiaFont}"/>
+
+    <TextBox Grid.Row="1" Grid.Column="1"
+             Name="hexView"
+             Text="{Binding HexText}"
+             CaretIndex="{Binding HexCursorPos, Mode=TwoWay}"
+             IsReadOnly="True"
+             Background="Transparent"
+             SizeChanged="HexViewSizeChanged"
+             FontSize="13"
+             FontFamily="{StaticResource CaskaydiaFont}"/>
+
+    <TextBox Grid.Row="1" Grid.Column="2"
+             Text="{Binding AsciiText}"
+             CaretIndex="{Binding AsciiCursorPos, Mode=TwoWay}"
+             IsReadOnly="True"
+             Background="Transparent"
+             FontSize="13"
+             FontFamily="{StaticResource CaskaydiaFont}"/>
+    
+    <ScrollBar Grid.Row="1" Grid.Column="3"
+               Orientation="Vertical"
+               Maximum="{Binding MaximumScroll}"
+               Value="{Binding CurrentScroll}"/>
+
+    <StackPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="4"
+                Spacing="15"
+                Orientation="Vertical">
+      <DataGrid ItemsSource="{Binding DataTypes}"
+                Margin="5"
+                CanUserReorderColumns="False"
+                CanUserResizeColumns="False"
+                CanUserSortColumns="False"
+                IsReadOnly="True">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Type" Binding="{Binding Description}" />
+          <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+        </DataGrid.Columns>
+      </DataGrid>
+
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <RadioButton Content="Little endian" GroupName="Endianness" IsChecked="True" />
+        <RadioButton Content="Big endian" GroupName="Endianness" IsChecked="{Binding IsBigEndian}" />
+      </StackPanel>
+      <DockPanel Margin="0 0 10 0">
+        <TextBlock DockPanel.Dock="Left" Text="Custom encoding name: " VerticalAlignment="Center" />
+        <TextBox Watermark="code page name"
+                 Text="{Binding CustomEncodingName}" />
+      </DockPanel>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/src/SceneGate.UI.Formats/Common/HexViewerView.axaml
+++ b/src/SceneGate.UI.Formats/Common/HexViewerView.axaml
@@ -24,6 +24,7 @@
 
     <TextBox Grid.Row="1" Grid.Column="0"
              Text="{Binding OffsetsText}"
+             Classes="NonScrollable"
              IsReadOnly="True"
              Background="Transparent"
              FontSize="13"
@@ -32,20 +33,28 @@
     <TextBox Grid.Row="1" Grid.Column="1"
              Name="hexView"
              Text="{Binding HexText}"
+             Classes="NonScrollable"
              CaretIndex="{Binding HexCursorPos, Mode=TwoWay}"
              IsReadOnly="True"
              Background="Transparent"
-             SizeChanged="HexViewSizeChanged"
              FontSize="13"
-             FontFamily="{StaticResource CaskaydiaFont}"/>
+             FontFamily="{StaticResource CaskaydiaFont}"
+             PointerWheelChanged="ViewsPointerWheelChanged"
+             KeyUp="ViewsKeyUp"
+             KeyDown="ViewsKeyDown"
+             SizeChanged="HexViewSizeChanged" />
 
     <TextBox Grid.Row="1" Grid.Column="2"
              Text="{Binding AsciiText}"
+             Classes="NonScrollable"
              CaretIndex="{Binding AsciiCursorPos, Mode=TwoWay}"
              IsReadOnly="True"
              Background="Transparent"
              FontSize="13"
-             FontFamily="{StaticResource CaskaydiaFont}"/>
+             FontFamily="{StaticResource CaskaydiaFont}"
+             PointerWheelChanged="ViewsPointerWheelChanged"
+             KeyUp="ViewsKeyUp"
+             KeyDown="ViewsKeyDown" />
     
     <ScrollBar Grid.Row="1" Grid.Column="3"
                Orientation="Vertical"

--- a/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
@@ -1,8 +1,8 @@
 ﻿namespace SceneGate.UI.Formats.Common;
 
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
-using Avalonia.Media.TextFormatting;
 
 public partial class HexViewerView : UserControl
 {
@@ -25,6 +25,39 @@ public partial class HexViewerView : UserControl
 
     private void HexViewSizeChanged(object? sender, SizeChangedEventArgs e)
     {
-        ViewModel.VisibleTextRows = (int)(e.NewSize.Height / lineHeight);
+        ViewModel.VisibleTextRows = (int)(e.NewSize.Height / lineHeight) - 1;
+    }
+
+    private void ViewsPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        ViewModel.CurrentScroll += (e.Delta.Y > 0) ? -1 : 1;
+    }
+
+    private void ViewsKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Down) {
+            // Should work with ascii or hex cursors as they are synched
+            int asciiCharsPerLine = HexViewerViewModel.BytesPerRow * 2;
+            int y = ViewModel.AsciiCursorPos / asciiCharsPerLine;
+            if (y + 1 >= ViewModel.VisibleTextRows) {
+                ViewModel.CurrentScroll++;
+            }
+        } else if (e.Key == Key.Up) {
+            int asciiCharsPerLine = HexViewerViewModel.BytesPerRow * 2;
+            int y = ViewModel.AsciiCursorPos / asciiCharsPerLine;
+            if (y == 0) {
+                ViewModel.CurrentScroll--;
+            }
+        }
+    }
+
+    private void ViewsKeyUp(object? sender, KeyEventArgs e)
+    {
+        // PageDown and PageUp doesn't work with KeyDown event :/
+        if (e.Key == Key.PageDown) {
+            ViewModel.CurrentScroll += ViewModel.VisibleTextRows - 2;
+        } else if (e.Key == Key.PageUp) {
+            ViewModel.CurrentScroll -= ViewModel.VisibleTextRows - 2;
+        }
     }
 }

--- a/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
@@ -4,10 +4,16 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 
+/// <summary>
+/// Hexadecimal viewer for binary content.
+/// </summary>
 public partial class HexViewerView : UserControl
 {
     private readonly int lineHeight;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HexViewerView"/> class.
+    /// </summary>
     public HexViewerView()
     {
         InitializeComponent();

--- a/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewerView.axaml.cs
@@ -1,0 +1,30 @@
+﻿namespace SceneGate.UI.Formats.Common;
+
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+
+public partial class HexViewerView : UserControl
+{
+    private readonly int lineHeight;
+
+    public HexViewerView()
+    {
+        InitializeComponent();
+
+        var fontTypeFace = new Typeface(hexView.FontFamily);
+        if (FontManager.Current.TryGetGlyphTypeface(fontTypeFace, out var glyphTypeface)) {
+            double lineSpacingEm = (double)glyphTypeface.Metrics.LineSpacing / glyphTypeface.Metrics.DesignEmHeight;
+            lineHeight = (int)(hexView.FontSize * lineSpacingEm);
+        } else {
+            lineHeight = (int)hexView.FontSize;
+        }
+    }
+
+    private HexViewerViewModel ViewModel => (DataContext as HexViewerViewModel)!;
+
+    private void HexViewSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        ViewModel.VisibleTextRows = (int)(e.NewSize.Height / lineHeight);
+    }
+}

--- a/src/SceneGate.UI.Formats/Common/HexViewerViewModel.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewerViewModel.cs
@@ -109,6 +109,10 @@ public partial class HexViewerViewModel : ObservableObject, IFormatViewModel
     public int CurrentScroll {
         get => currentScroll;
         set {
+            if (value < 0) {
+                value = 0;
+            }
+
             if (SetProperty(ref currentScroll, value)) {
                 UpdateVisibleText();
             }

--- a/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
@@ -1,7 +1,10 @@
 ﻿namespace SceneGate.UI.Formats;
+
 using System;
+using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Texts;
 using Yarhl.FileFormat;
+using Yarhl.IO;
 using Yarhl.Media.Text;
 
 /// <summary>
@@ -16,13 +19,17 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
             return new PoViewModel(poFormat);
         }
 
+        if (format is IBinary binaryFormat) {
+            return new HexViewerViewModel(binaryFormat.Stream);
+        }
+
         throw new NotSupportedException("Invalid format");
     }
 
     /// <inheritdoc/>
     public bool CanShow(IFormat format)
     {
-        if (format is Po) {
+        if (format is Po or IBinary) {
             return true;
         }
 

--- a/src/SceneGate.UI/MainWindow.axaml.cs
+++ b/src/SceneGate.UI/MainWindow.axaml.cs
@@ -1,17 +1,27 @@
 ﻿namespace SceneGate.UI;
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using FluentAvalonia.UI.Windowing;
 
 public partial class MainWindow : AppWindow
 {
+    private const string DevVersion = "0.0.0-dev";
+
     public MainWindow()
     {
         InitializeComponent();
 
-        Version version = Assembly.GetExecutingAssembly().GetName().Version!;
-        string versionText = (version.Build == 0) ? "DEVELOPMENT BUILD" : $"v{version}";
+        // Get assembly with the build metadata (except commit number)
+        string assemblyPath = Assembly.GetExecutingAssembly().Location;
+        string version = FileVersionInfo.GetVersionInfo(assemblyPath).ProductVersion
+            ?? DevVersion;
+        if (version.Contains('+')) {
+            version = version[..version.IndexOf('+')];
+        }
+
+        string versionText = (version == DevVersion) ? "DEVELOPMENT BUILD" : $"v{version}";
         Title = $"SceneGate ~~ {versionText}";
     }
 }

--- a/src/SceneGate.UI/SceneGate.UI.csproj
+++ b/src/SceneGate.UI/SceneGate.UI.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <Description>Main UI components for SceneGate application.</Description>
 
+    <!-- Overwritten during build system - This is the value for devs -->
+    <Version>0.0.0-dev</Version>
+
     <TargetFramework>net8.0</TargetFramework>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/SceneGate.UI/Styling/ControlsStyle.axaml
+++ b/src/SceneGate.UI/Styling/ControlsStyle.axaml
@@ -5,27 +5,20 @@
         xmlns:cd="using:SceneGate.UI.ControlsData">
 
   <Design.PreviewWith>
-    <Border Padding="30" MinWidth="350">
-      <TreeView Classes="Compact">
-        <TreeViewItem Header="Item 1" />
-        <TreeViewItem Header="Item 2">
-          <TreeViewItem Header="SubItem1" />
-          <TreeViewItem Header="SubItem2" />
-          <TreeViewItem Header="SubItem3">
-            <TreeViewItem Header="SubItem Item1" />
-            <TreeViewItem Header="SubItem Item2" />
-            <TreeViewItem Header="SubItem Item3" />
-          </TreeViewItem>
-        </TreeViewItem>
-        <TreeViewItem Header="Item3" />
-        <TreeViewItem Header="Item4" />
-      </TreeView>
+    <Border Padding="30" MinWidth="350" Height="300">
+      <TextBox Text="a&#xa;b&#xa;c" IsReadOnly="True" MaxHeight="40" />
     </Border>
   </Design.PreviewWith>
 
   <!-- SelectableTextBlock doesn't have a SelectionForegroundBrush so it doesn't look right on Light themes -->
   <Style Selector="SelectableTextBlock">
     <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+  </Style>
+
+  <!-- Non-scrollable textbox for HexView -->
+  <Style Selector="TextBox.NonScrollable">
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
   </Style>
   
   <Style Selector="TreeView.Compact TreeViewItem">


### PR DESCRIPTION
Implement with Avalonia a simple hexadecimal viewer. Creating a full feature control would take a lot of time and there are already great apps. This control provides the basic features to quickly analyze file content. It works with any `IBinary` format.

It's not an editor, we can only view.

It provides with:
- Efficient scrolling without loading the full file
- Hexadecimal (16 bytes per row) and ASCII views
- Data viewer for different integer types, string and custom encoding, including big endian

This is a port from the Eto-based implementation in #10

This PR closes #9

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- There is a simple way to see binary format content

## Follow-up work

- There is a better full featured control in [Droppers HexEditorControl](https://github.com/Droppers/HexEditorControl). Once it support the latest version of Avalonia we could migrate to use it.

## Example

![image](https://github.com/SceneGate/SceneGate/assets/3107481/05a1524a-91cd-4fbd-af34-50478e0ff5cc)
