### PR TITLE
✨ New format view to see binary data as raw palettes

### DIFF
--- a/src/SceneGate.UI.Formats/Common/HexViewerViewModel.cs
+++ b/src/SceneGate.UI.Formats/Common/HexViewerViewModel.cs
@@ -44,6 +44,16 @@ public partial class HexViewerViewModel : ObservableObject, IFormatViewModel
     /// <summary>
     /// Initializes a new instance of the <see cref="HexViewerViewModel" /> class.
     /// </summary>
+    /// <param name="binary">Data to view.</param>
+    public HexViewerViewModel(IBinary binary)
+        : this(binary.Stream)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HexViewerViewModel" /> class.
+    /// </summary>
+    /// <param name="stream">Data to view.</param>
     public HexViewerViewModel(Stream stream)
     {
         // Make sure that the shift-jis encoding is initialized.

--- a/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
+++ b/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
@@ -1,35 +1,55 @@
 ﻿namespace SceneGate.UI.Formats.Controls;
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Avalonia.Data.Converters;
 using Avalonia;
+using Avalonia.Data.Converters;
 
+/// <summary>
+/// Value converter for a number and its hexadecimal string representation
+/// for the NumericUpDown control.
+/// </summary>
 public class HexadecimalValueConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    /// <summary>
+    /// Converts a string value with an hexadecimal number into a target type.
+    /// </summary>
+    /// <param name="value">The hexadecimal string value.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <param name="parameter">Not used.</param>
+    /// <param name="culture">The culture to parse the string.</param>
+    /// <returns>The integer representation of the hexadecimal string.</returns>
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         string? str = value?.ToString();
         if (string.IsNullOrWhiteSpace(str)) {
             return AvaloniaProperty.UnsetValue;
         }
 
-        if (int.TryParse(str, NumberStyles.HexNumber, culture, out int x)) {
-            return (decimal)x;
+        if (long.TryParse(str, NumberStyles.HexNumber, culture, out long x)) {
+            return System.Convert.ChangeType(x, targetType);
         }
 
         return AvaloniaProperty.UnsetValue;
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    /// <summary>
+    /// Converts a decimal number into an hexadecimal string representation.
+    /// </summary>
+    /// <param name="value">The number to convert.</param>
+    /// <param name="targetType">The string type.</param>
+    /// <param name="parameter">Not used.</param>
+    /// <param name="culture">The culture information.</param>
+    /// <returns>Its hexadecimal string representation.</returns>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
+        if (value is null) {
+            return AvaloniaProperty.UnsetValue;
+        }
+
         try {
             if (value is decimal d) {
-                return $"{(long)d:X8}";
+                return string.Format(culture, "{0:X8}", (long)d);
             }
 
             return $"Invalid type: {value.GetType()}";

--- a/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
+++ b/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
@@ -27,7 +27,7 @@ public class HexadecimalValueConverter : IValueConverter
         }
 
         if (long.TryParse(str, NumberStyles.HexNumber, culture, out long x)) {
-            return System.Convert.ChangeType(x, targetType);
+            return (decimal)x;
         }
 
         return AvaloniaProperty.UnsetValue;

--- a/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
+++ b/src/SceneGate.UI.Formats/Controls/HexadecimalValueConverter.cs
@@ -1,0 +1,40 @@
+﻿namespace SceneGate.UI.Formats.Controls;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Data.Converters;
+using Avalonia;
+
+public class HexadecimalValueConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        string? str = value?.ToString();
+        if (string.IsNullOrWhiteSpace(str)) {
+            return AvaloniaProperty.UnsetValue;
+        }
+
+        if (int.TryParse(str, NumberStyles.HexNumber, culture, out int x)) {
+            return (decimal)x;
+        }
+
+        return AvaloniaProperty.UnsetValue;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        try {
+            if (value is decimal d) {
+                return $"{(long)d:X8}";
+            }
+
+            return $"Invalid type: {value.GetType()}";
+        } catch (Exception ex) {
+            return ex.Message;
+        }
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -140,11 +140,9 @@
                            Margin="0 5"
                            CornerRadius="0 4 4 0"
                            SelectedIndex="0"
-                           IsEditable="False">
-          <fluent:FAComboBoxItem Content="BGR555" />
-          <fluent:FAComboBoxItem Content="RGB32" />
-          <fluent:FAComboBoxItem Content="RGBA32" />
-        </fluent:FAComboBox>
+                           IsEditable="False"
+                           SelectedItem="{Binding ColorKind}"
+                           ItemsSource="{Binding AllColorKinds}"/>
       </Grid>
 
       <TextBlock Grid.Row="2"

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -52,7 +52,7 @@
         <NumericUpDown Grid.Row="0" Grid.Column="1"
                        Name="OffsetNumericBox"
                        Margin="0 5"
-                       Width="150"
+                       Width="160"
                        CornerRadius="0,4,4,0"
                        FormatString="0"
                        Value="{Binding Offset}"

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -54,6 +54,7 @@
                        CornerRadius="0,4,4,0"
                        Value="{Binding Offset}"
                        Minimum="0"
+                       Maximum="{Binding MaximumOffset}"
                        FontFamily="{StaticResource CaskaydiaFont}"
                        VerticalContentAlignment="Center">
           <NumericUpDown.TextConverter>
@@ -83,6 +84,7 @@
                        CornerRadius="0,4,4,0"
                        Value="{Binding Length}"
                        Minimum="0"
+                       Maximum="{Binding MaximumLength}"
                        FontFamily="{StaticResource CaskaydiaFont}"
                        VerticalContentAlignment="Center">
           <NumericUpDown.TextConverter>

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -50,8 +50,11 @@
                      VerticalAlignment="Center" />
         </Border>
         <NumericUpDown Grid.Row="0" Grid.Column="1"
+                       Name="OffsetNumericBox"
                        Margin="0 5"
+                       Width="150"
                        CornerRadius="0,4,4,0"
+                       FormatString="0"
                        Value="{Binding Offset}"
                        Minimum="0"
                        Maximum="{Binding MaximumOffset}"
@@ -64,7 +67,8 @@
         <CheckBox Grid.Row="0" Grid.Column="2"
                   Margin="10 5"
                   IsChecked="True"
-                  Content="Hexadecimal" />
+                  Content="Hexadecimal"
+                  IsCheckedChanged="OffsetHexCheckboxChecked"/>
 
         <!-- Length -->
         <Border Grid.Row="1" Grid.Column="0"
@@ -80,21 +84,21 @@
                      VerticalAlignment="Center" />
         </Border>
         <NumericUpDown Grid.Row="1" Grid.Column="1"
+                       Name="LengthNumericBox"
                        Margin="0 5"
                        CornerRadius="0,4,4,0"
+                       FormatString="0"
                        Value="{Binding Length}"
                        Minimum="0"
                        Maximum="{Binding MaximumLength}"
                        FontFamily="{StaticResource CaskaydiaFont}"
                        VerticalContentAlignment="Center">
-          <NumericUpDown.TextConverter>
-            <controls:HexadecimalValueConverter />
-          </NumericUpDown.TextConverter>
         </NumericUpDown>
         <CheckBox Grid.Row="1" Grid.Column="2"
                   Margin="10 5"
-                  IsChecked="True"
-                  Content="Hexadecimal" />
+                  IsChecked="False"
+                  Content="Hexadecimal"
+                  IsCheckedChanged="LengthHexCheckboxChecked"/>
 
         <!-- Colors per palette -->
         <Border Grid.Row="2" Grid.Column="0"

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -1,0 +1,136 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="using:SceneGate.UI.Formats.Graphics"
+             xmlns:controls="using:SceneGate.UI.Formats.Controls"
+             xmlns:fluent="using:FluentAvalonia.UI.Controls"
+             mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="600"
+             x:Class="SceneGate.UI.Formats.Graphics.BinaryPaletteView"
+             x:DataType="local:BinaryPaletteViewModel">
+
+  <Design.DataContext>
+    <local:BinaryPaletteViewModel />
+  </Design.DataContext>
+  
+  <Grid ColumnDefinitions="Auto,*,Auto">
+    <Grid Grid.Column="0"
+          ColumnDefinitions="Auto,Auto,Auto"
+          RowDefinitions="Auto,Auto,Auto,Auto,*"
+          Margin="10">
+
+      <!-- Offset -->
+      <Border Grid.Row="0" Grid.Column="0"
+              Height="32"
+              Margin="0 5"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="4,0,0,4">
+        <TextBlock Text="Offset"
+                   Padding="5 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <NumericUpDown Grid.Row="0" Grid.Column="1"
+                     Margin="0 5"
+                     CornerRadius="0,4,4,0"
+                     Value="{Binding Offset}"
+                     Minimum="0"
+                     FontFamily="{StaticResource CaskaydiaFont}"
+                     VerticalContentAlignment="Center">
+        <NumericUpDown.TextConverter>
+          <controls:HexadecimalValueConverter />
+        </NumericUpDown.TextConverter>
+      </NumericUpDown>
+      <CheckBox Grid.Row="0" Grid.Column="2"
+                Margin="10 5"
+                IsChecked="True"
+                Content="Hexadecimal" />
+
+      <!-- Length -->
+      <Border Grid.Row="1" Grid.Column="0"
+              Margin="0 5"
+              Height="32"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="4,0,0,4">
+        <TextBlock Text="Length"
+                   Padding="5 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <NumericUpDown Grid.Row="1" Grid.Column="1"
+                     Margin="0 5"
+                     CornerRadius="0,4,4,0"
+                     Value="{Binding Length}"
+                     Minimum="0"
+                     FontFamily="{StaticResource CaskaydiaFont}"
+                     VerticalContentAlignment="Center">
+        <NumericUpDown.TextConverter>
+          <controls:HexadecimalValueConverter />
+        </NumericUpDown.TextConverter>
+      </NumericUpDown>
+      <CheckBox Grid.Row="1" Grid.Column="2"
+                Margin="10 5"
+                IsChecked="True"
+                Content="Hexadecimal" />
+
+      <!-- Colors per palette -->
+      <Border Grid.Row="2" Grid.Column="0"
+              Margin="0 5"
+              Height="32"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="4,0,0,4">
+        <TextBlock Text="Colors per palette"
+                   Padding="5 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <NumericUpDown Grid.Row="2" Grid.Column="1"
+                     Margin="0 5"
+                     CornerRadius="0,4,4,0"
+                     Value="{Binding ColorsPerPalette}"
+                     FormatString="0"
+                     Minimum="0"
+                     Maximum="256"
+                     FontFamily="{StaticResource CaskaydiaFont}"
+                     VerticalContentAlignment="Center" />
+
+      <!-- Format -->
+      <Border Grid.Row="3" Grid.Column="0"
+              Margin="0 5"
+              Height="32"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="4,0,0,4">
+        <TextBlock Text="Color format"
+                   Padding="5 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <fluent:FAComboBox Grid.Row="3" Grid.Column="1"
+                         Margin="0 5"
+                         CornerRadius="0 4 4 0"
+                         SelectedIndex="0"
+                         IsEditable="False">
+        <fluent:FAComboBoxItem Content="BGR555" />
+        <fluent:FAComboBoxItem Content="RGB32" />
+        <fluent:FAComboBoxItem Content="RGBA32" />
+      </fluent:FAComboBox>
+
+      <TextBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
+              Text="{Binding HexContent}"
+              IsReadOnly="True"
+              Background="Transparent"
+              FontSize="13"
+              FontFamily="{StaticResource CaskaydiaFont}" />
+    </Grid>
+
+    <local:PaletteView Grid.Column="1" DataContext="{Binding PaletteInfo}" />
+  </Grid>
+</UserControl>

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -13,124 +13,160 @@
     <local:BinaryPaletteViewModel />
   </Design.DataContext>
   
-  <Grid ColumnDefinitions="Auto,*,Auto">
+  <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+
+    <Border Grid.Column="0"
+            BorderThickness="1"
+            CornerRadius="4"
+            BorderBrush="{DynamicResource ControlElevationBorderBrush}">
     <Grid Grid.Column="0"
-          ColumnDefinitions="Auto,Auto,Auto"
-          RowDefinitions="Auto,Auto,Auto,Auto,*"
-          Margin="10">
-
-      <!-- Offset -->
-      <Border Grid.Row="0" Grid.Column="0"
-              Height="32"
-              Margin="0 5"
-              Background="{DynamicResource TextControlBackgroundDisabled}"
-              BorderBrush="{DynamicResource TextControlBorderBrush}"
-              BorderThickness="1,1,0,1"
-              CornerRadius="4,0,0,4">
-        <TextBlock Text="Offset"
-                   Padding="5 0"
-                   FontWeight="SemiBold"
-                   VerticalAlignment="Center" />
+          RowDefinitions="Auto,Auto,Auto,*">
+      <Border Grid.Row="0"
+        CornerRadius="4 4 0 0"
+        Background="{DynamicResource AccentFillColorDefaultBrush}"
+        Padding="5">
+        <TextBlock Text="Palette format"
+                   Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                   Theme="{StaticResource SubtitleTextBlockStyle}"
+                   HorizontalAlignment="Center"/>
       </Border>
-      <NumericUpDown Grid.Row="0" Grid.Column="1"
-                     Margin="0 5"
-                     CornerRadius="0,4,4,0"
-                     Value="{Binding Offset}"
-                     Minimum="0"
-                     FontFamily="{StaticResource CaskaydiaFont}"
-                     VerticalContentAlignment="Center">
-        <NumericUpDown.TextConverter>
-          <controls:HexadecimalValueConverter />
-        </NumericUpDown.TextConverter>
-      </NumericUpDown>
-      <CheckBox Grid.Row="0" Grid.Column="2"
-                Margin="10 5"
-                IsChecked="True"
-                Content="Hexadecimal" />
 
-      <!-- Length -->
-      <Border Grid.Row="1" Grid.Column="0"
-              Margin="0 5"
-              Height="32"
-              Background="{DynamicResource TextControlBackgroundDisabled}"
-              BorderBrush="{DynamicResource TextControlBorderBrush}"
-              BorderThickness="1,1,0,1"
-              CornerRadius="4,0,0,4">
-        <TextBlock Text="Length"
-                   Padding="5 0"
-                   FontWeight="SemiBold"
-                   VerticalAlignment="Center" />
-      </Border>
-      <NumericUpDown Grid.Row="1" Grid.Column="1"
-                     Margin="0 5"
-                     CornerRadius="0,4,4,0"
-                     Value="{Binding Length}"
-                     Minimum="0"
-                     FontFamily="{StaticResource CaskaydiaFont}"
-                     VerticalContentAlignment="Center">
-        <NumericUpDown.TextConverter>
-          <controls:HexadecimalValueConverter />
-        </NumericUpDown.TextConverter>
-      </NumericUpDown>
-      <CheckBox Grid.Row="1" Grid.Column="2"
-                Margin="10 5"
-                IsChecked="True"
-                Content="Hexadecimal" />
+      <Grid Grid.Row="1"
+            ColumnDefinitions="Auto,Auto,Auto"
+            RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+            Margin="10 3">
 
-      <!-- Colors per palette -->
-      <Border Grid.Row="2" Grid.Column="0"
-              Margin="0 5"
-              Height="32"
-              Background="{DynamicResource TextControlBackgroundDisabled}"
-              BorderBrush="{DynamicResource TextControlBorderBrush}"
-              BorderThickness="1,1,0,1"
-              CornerRadius="4,0,0,4">
-        <TextBlock Text="Colors per palette"
-                   Padding="5 0"
-                   FontWeight="SemiBold"
-                   VerticalAlignment="Center" />
-      </Border>
-      <NumericUpDown Grid.Row="2" Grid.Column="1"
-                     Margin="0 5"
-                     CornerRadius="0,4,4,0"
-                     Value="{Binding ColorsPerPalette}"
-                     FormatString="0"
-                     Minimum="0"
-                     Maximum="256"
-                     FontFamily="{StaticResource CaskaydiaFont}"
-                     VerticalContentAlignment="Center" />
+        <!-- Offset -->
+        <Border Grid.Row="0" Grid.Column="0"
+                Height="32"
+                Margin="0 5"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+          <TextBlock Text="Offset"
+                     Padding="5 0"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center" />
+        </Border>
+        <NumericUpDown Grid.Row="0" Grid.Column="1"
+                       Margin="0 5"
+                       CornerRadius="0,4,4,0"
+                       Value="{Binding Offset}"
+                       Minimum="0"
+                       FontFamily="{StaticResource CaskaydiaFont}"
+                       VerticalContentAlignment="Center">
+          <NumericUpDown.TextConverter>
+            <controls:HexadecimalValueConverter />
+          </NumericUpDown.TextConverter>
+        </NumericUpDown>
+        <CheckBox Grid.Row="0" Grid.Column="2"
+                  Margin="10 5"
+                  IsChecked="True"
+                  Content="Hexadecimal" />
 
-      <!-- Format -->
-      <Border Grid.Row="3" Grid.Column="0"
-              Margin="0 5"
-              Height="32"
-              Background="{DynamicResource TextControlBackgroundDisabled}"
-              BorderBrush="{DynamicResource TextControlBorderBrush}"
-              BorderThickness="1,1,0,1"
-              CornerRadius="4,0,0,4">
-        <TextBlock Text="Color format"
-                   Padding="5 0"
-                   FontWeight="SemiBold"
-                   VerticalAlignment="Center" />
-      </Border>
-      <fluent:FAComboBox Grid.Row="3" Grid.Column="1"
-                         Margin="0 5"
-                         CornerRadius="0 4 4 0"
-                         SelectedIndex="0"
-                         IsEditable="False">
-        <fluent:FAComboBoxItem Content="BGR555" />
-        <fluent:FAComboBoxItem Content="RGB32" />
-        <fluent:FAComboBoxItem Content="RGBA32" />
-      </fluent:FAComboBox>
+        <!-- Length -->
+        <Border Grid.Row="1" Grid.Column="0"
+                Margin="0 5"
+                Height="32"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+          <TextBlock Text="Length"
+                     Padding="5 0"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center" />
+        </Border>
+        <NumericUpDown Grid.Row="1" Grid.Column="1"
+                       Margin="0 5"
+                       CornerRadius="0,4,4,0"
+                       Value="{Binding Length}"
+                       Minimum="0"
+                       FontFamily="{StaticResource CaskaydiaFont}"
+                       VerticalContentAlignment="Center">
+          <NumericUpDown.TextConverter>
+            <controls:HexadecimalValueConverter />
+          </NumericUpDown.TextConverter>
+        </NumericUpDown>
+        <CheckBox Grid.Row="1" Grid.Column="2"
+                  Margin="10 5"
+                  IsChecked="True"
+                  Content="Hexadecimal" />
 
-      <TextBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
-              Text="{Binding HexContent}"
-              IsReadOnly="True"
-              Background="Transparent"
-              FontSize="13"
-              FontFamily="{StaticResource CaskaydiaFont}" />
+        <!-- Colors per palette -->
+        <Border Grid.Row="2" Grid.Column="0"
+                Margin="0 5"
+                Height="32"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+          <TextBlock Text="Colors per palette"
+                     Padding="5 0"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center" />
+        </Border>
+        <NumericUpDown Grid.Row="2" Grid.Column="1"
+                       Margin="0 5"
+                       CornerRadius="0,4,4,0"
+                       Value="{Binding ColorsPerPalette}"
+                       FormatString="0"
+                       Minimum="0"
+                       Maximum="256"
+                       FontFamily="{StaticResource CaskaydiaFont}"
+                       VerticalContentAlignment="Center" />
+
+        <!-- Format -->
+        <Border Grid.Row="3" Grid.Column="0"
+                Margin="0 5"
+                Height="32"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+          <TextBlock Text="Color format"
+                     Padding="5 0"
+                     FontWeight="SemiBold"
+                     VerticalAlignment="Center" />
+        </Border>
+        <fluent:FAComboBox Grid.Row="3" Grid.Column="1"
+                           Margin="0 5"
+                           CornerRadius="0 4 4 0"
+                           SelectedIndex="0"
+                           IsEditable="False">
+          <fluent:FAComboBoxItem Content="BGR555" />
+          <fluent:FAComboBoxItem Content="RGB32" />
+          <fluent:FAComboBoxItem Content="RGBA32" />
+        </fluent:FAComboBox>
+      </Grid>
+
+      <TextBlock Grid.Row="2"
+                 Margin="12 0"
+                 FontWeight="SemiBold"
+                 Text="Palette bytes:"/>
+      <TextBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
+               Margin="10 4"
+               Text="{Binding HexContent}"
+               IsReadOnly="True"
+               Background="Transparent"
+               FontSize="13"
+               FontFamily="{StaticResource CaskaydiaFont}" />
     </Grid>
+    </Border>
 
-    <local:PaletteView Grid.Column="1" DataContext="{Binding PaletteInfo}" />
+    <Border Grid.Column="2"
+            CornerRadius="5"
+            Background="{DynamicResource AccentFillColorDefaultBrush}"
+            Height="400"
+             Padding="5">
+      <TextBlock Text="P&#xa;r&#xa;e&#xa;v&#xa;i&#xa;e&#xa;w"
+                 Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
+                 Theme="{StaticResource SubtitleTextBlockStyle}"
+                 TextAlignment="Center"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"/>
+    </Border>
+    <local:PaletteView Grid.Column="3" DataContext="{Binding PaletteInfo}" />
   </Grid>
 </UserControl>

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
@@ -1,6 +1,8 @@
 ﻿namespace SceneGate.UI.Formats.Graphics;
 
+using System.Globalization;
 using Avalonia.Controls;
+using SceneGate.UI.Formats.Controls;
 
 /// <summary>
 /// View to see a binary stream as a palette.
@@ -13,5 +15,34 @@ public partial class BinaryPaletteView : UserControl
     public BinaryPaletteView()
     {
         InitializeComponent();
+    }
+
+    private void OffsetHexCheckboxChecked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var checkbox = sender as CheckBox;
+        OffsetNumericBox.TextConverter = (checkbox?.IsChecked ?? false)
+            ? new HexadecimalValueConverter()
+            : null;
+        RefreshNumericBox(OffsetNumericBox);
+    }
+
+    private void LengthHexCheckboxChecked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var checkbox = sender as CheckBox;
+        LengthNumericBox.TextConverter = (checkbox?.IsChecked ?? false)
+            ? new HexadecimalValueConverter()
+            : null;
+        RefreshNumericBox(LengthNumericBox);
+    }
+
+    private void RefreshNumericBox(NumericUpDown box)
+    {
+        // Due to a bug in Avalonia, it doesn't refresh the text when the converter changes
+        // We do it manually
+        if (box.TextConverter is null) {
+            box.Text = box.Value?.ToString(box.FormatString, box.NumberFormat);
+        } else {
+            box.Text = box.TextConverter.ConvertBack(box.Value, typeof(string), null, CultureInfo.CurrentCulture)?.ToString();
+        }
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
@@ -1,0 +1,11 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using Avalonia.Controls;
+
+public partial class BinaryPaletteView : UserControl
+{
+    public BinaryPaletteView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
@@ -2,8 +2,14 @@
 
 using Avalonia.Controls;
 
+/// <summary>
+/// View to see a binary stream as a palette.
+/// </summary>
 public partial class BinaryPaletteView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryPaletteView"/> class.
+    /// </summary>
     public BinaryPaletteView()
     {
         InitializeComponent();

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
@@ -1,11 +1,9 @@
 ﻿namespace SceneGate.UI.Formats.Graphics;
+
 using System;
-using System.Collections.Generic;
+using System.Buffers;
 using System.IO;
-using System.Linq;
-using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Texim.Colors;
@@ -15,7 +13,11 @@ using Yarhl.IO;
 
 public partial class BinaryPaletteViewModel : ObservableObject
 {
-    private readonly BinaryFormat binaryFormat;
+    private const int DefaultMaxLength = 256 * 2 * 16;
+
+    private readonly Stream stream;
+    private readonly IBinary binaryFormat;
+    private readonly StringBuilder hexBuilder;
 
     [ObservableProperty]
     private IPaletteCollection rawPalettes;
@@ -27,7 +29,13 @@ public partial class BinaryPaletteViewModel : ObservableObject
     private long offset;
 
     [ObservableProperty]
-    private long length;
+    private long maximumOffset;
+
+    [ObservableProperty]
+    private int length;
+
+    [ObservableProperty]
+    private int maximumLength;
 
     [ObservableProperty]
     private int colorsPerPalette;
@@ -44,19 +52,47 @@ public partial class BinaryPaletteViewModel : ObservableObject
             var random = new Random(42);
             byte[] colorBytes = new byte[256 * 2];
             random.NextBytes(colorBytes);
-            binaryFormat = new BinaryFormat(DataStreamFactory.FromArray(colorBytes));
+            stream = DataStreamFactory.FromArray(colorBytes);
+            binaryFormat = new BinaryFormat(stream);
         } else {
+            stream = null!;
             binaryFormat = null!;
         }
 
-        length = binaryFormat.Stream.Length;
+        hexBuilder = new StringBuilder();
+
+        maximumOffset = stream.Length - 512;
+        length = 512;
+        maximumLength = (int)stream.Length;
         colorsPerPalette = 16;
+        hexContent = string.Empty;
 
         rawPalettes = new PaletteCollection();
         PaletteInfo = new PaletteViewModel(rawPalettes) {
             IsModelPropertyVisible = false,
         };
 
+        ReadRawPalette();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryPaletteViewModel"/> class.
+    /// </summary>
+    /// <param name="binary">The raw data to analyze.</param>
+    public BinaryPaletteViewModel(IBinary binary)
+        : this()
+    {
+        ArgumentNullException.ThrowIfNull(nameof(binary));
+
+        stream = binary.Stream;
+        binaryFormat = binary;
+
+        // Try to auto-detect some good default settings
+        offset = 0;
+        length = stream.Length > DefaultMaxLength ? DefaultMaxLength : (int)stream.Length;
+        maximumOffset = stream.Length - length;
+        maximumLength = length;
+        colorsPerPalette = length >= (256 * 2) ? 256 : 16;
 
         ReadRawPalette();
     }
@@ -66,25 +102,23 @@ public partial class BinaryPaletteViewModel : ObservableObject
     /// </summary>
     /// <param name="stream">The raw data to analyze.</param>
     public BinaryPaletteViewModel(Stream stream)
+        : this(new BinaryFormat(stream))
     {
-        ArgumentNullException.ThrowIfNull(nameof(stream));
-
-        binaryFormat = new BinaryFormat(stream);
-
-        rawPalettes = new PaletteCollection();
-        PaletteInfo = new PaletteViewModel(rawPalettes) {
-            IsModelPropertyVisible = false,
-        };
-        ReadRawPalette();
     }
 
     partial void OnOffsetChanged(long value)
     {
+        MaximumLength = (stream.Length - value) > DefaultMaxLength
+            ? DefaultMaxLength
+            : (int)(stream.Length - value);
+
         ReadRawPalette();
     }
 
-    partial void OnLengthChanged(long value)
+    partial void OnLengthChanged(int value)
     {
+        MaximumOffset = stream.Length - value;
+
         ReadRawPalette();
     }
 
@@ -95,37 +129,48 @@ public partial class BinaryPaletteViewModel : ObservableObject
 
     private void ReadRawPalette()
     {
-        byte[] buffer = new byte[Length];
-        binaryFormat.Stream.Position = Offset;
-        int read = binaryFormat.Stream.Read(buffer);
+        UpdateHexContent();
+        ConvertRawPalette();
+    }
 
-        var textBuilder = new StringBuilder();
+    private void UpdateHexContent()
+    {
+        stream.Position = Offset;
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(Length);
+        int read = stream.Read(buffer, 0, Length);
+
+        hexBuilder.Clear();
         for (int i = 0; i < read; i++) {
             if (i + 1 == read) {
-                textBuilder.AppendFormat("{0:X2}", buffer[i]);
+                hexBuilder.AppendFormat("{0:X2}", buffer[i]);
             } else if (i != 0 && ((i + 1) % 16 == 0)) {
-                textBuilder.AppendFormat("{0:X2}\n", buffer[i]);
+                hexBuilder.AppendFormat("{0:X2}\n", buffer[i]);
             } else {
-                textBuilder.AppendFormat("{0:X2} ", buffer[i]);
+                hexBuilder.AppendFormat("{0:X2} ", buffer[i]);
             }
         }
-        HexContent = textBuilder.ToString();
 
+        HexContent = hexBuilder.ToString();
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    private void ConvertRawPalette()
+    {
         var options = new RawPaletteParams() {
             Offset = Offset,
-            Size = (int)Length,
-            ColorEncoding = new Bgr555(),
+            Size = Length,
             ColorsPerPalette = ColorsPerPalette,
+            ColorEncoding = Bgr555.Instance,
         };
         var raw2Palette = new RawBinary2PaletteCollection(options);
 
         IPaletteCollection palettes;
         try {
-            palettes = raw2Palette.Convert(binaryFormat);
+            palettes = raw2Palette.Convert(new BinaryFormat(binaryFormat.Stream));
         } catch {
-            return;
+            palettes = new PaletteCollection();
         }
 
-        PaletteInfo.UpdatePalettes(palettes);
+        PaletteInfo.ReplacePalettes(palettes);
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
@@ -1,0 +1,131 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Texim.Colors;
+using Texim.Formats;
+using Texim.Palettes;
+using Yarhl.IO;
+
+public partial class BinaryPaletteViewModel : ObservableObject
+{
+    private readonly BinaryFormat binaryFormat;
+
+    [ObservableProperty]
+    private IPaletteCollection rawPalettes;
+
+    [ObservableProperty]
+    private PaletteViewModel paletteInfo;
+
+    [ObservableProperty]
+    private long offset;
+
+    [ObservableProperty]
+    private long length;
+
+    [ObservableProperty]
+    private int colorsPerPalette;
+
+    [ObservableProperty]
+    private string hexContent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryPaletteViewModel"/> class.
+    /// </summary>
+    public BinaryPaletteViewModel()
+    {
+        if (Design.IsDesignMode) {
+            var random = new Random(42);
+            byte[] colorBytes = new byte[256 * 2];
+            random.NextBytes(colorBytes);
+            binaryFormat = new BinaryFormat(DataStreamFactory.FromArray(colorBytes));
+        } else {
+            binaryFormat = null!;
+        }
+
+        length = binaryFormat.Stream.Length;
+        colorsPerPalette = 16;
+
+        rawPalettes = new PaletteCollection();
+        PaletteInfo = new PaletteViewModel(rawPalettes) {
+            IsModelPropertyVisible = false,
+        };
+
+
+        ReadRawPalette();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryPaletteViewModel"/> class.
+    /// </summary>
+    /// <param name="stream">The raw data to analyze.</param>
+    public BinaryPaletteViewModel(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(nameof(stream));
+
+        binaryFormat = new BinaryFormat(stream);
+
+        rawPalettes = new PaletteCollection();
+        PaletteInfo = new PaletteViewModel(rawPalettes) {
+            IsModelPropertyVisible = false,
+        };
+        ReadRawPalette();
+    }
+
+    partial void OnOffsetChanged(long value)
+    {
+        ReadRawPalette();
+    }
+
+    partial void OnLengthChanged(long value)
+    {
+        ReadRawPalette();
+    }
+
+    partial void OnColorsPerPaletteChanged(int value)
+    {
+        ReadRawPalette();
+    }
+
+    private void ReadRawPalette()
+    {
+        byte[] buffer = new byte[Length];
+        binaryFormat.Stream.Position = Offset;
+        int read = binaryFormat.Stream.Read(buffer);
+
+        var textBuilder = new StringBuilder();
+        for (int i = 0; i < read; i++) {
+            if (i + 1 == read) {
+                textBuilder.AppendFormat("{0:X2}", buffer[i]);
+            } else if (i != 0 && ((i + 1) % 16 == 0)) {
+                textBuilder.AppendFormat("{0:X2}\n", buffer[i]);
+            } else {
+                textBuilder.AppendFormat("{0:X2} ", buffer[i]);
+            }
+        }
+        HexContent = textBuilder.ToString();
+
+        var options = new RawPaletteParams() {
+            Offset = Offset,
+            Size = (int)Length,
+            ColorEncoding = new Bgr555(),
+            ColorsPerPalette = ColorsPerPalette,
+        };
+        var raw2Palette = new RawBinary2PaletteCollection(options);
+
+        IPaletteCollection palettes;
+        try {
+            palettes = raw2Palette.Convert(binaryFormat);
+        } catch {
+            return;
+        }
+
+        PaletteInfo.UpdatePalettes(palettes);
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
@@ -41,6 +41,9 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
     private int colorsPerPalette;
 
     [ObservableProperty]
+    private ColorKind colorKind;
+
+    [ObservableProperty]
     private string hexContent;
 
     /// <summary>
@@ -59,6 +62,7 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
             length = 512;
             maximumLength = 512;
             colorsPerPalette = 16;
+            colorKind = ColorKind.BGR555;
         } else {
             stream = null!;
             binaryFormat = null!;
@@ -95,6 +99,7 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
         maximumOffset = stream.Length - length;
         maximumLength = length;
         colorsPerPalette = length >= (256 * 2) ? 256 : 16;
+        colorKind = ColorKind.BGR555;
 
         ReadRawPalette();
     }
@@ -107,6 +112,11 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
         : this(new BinaryFormat(stream))
     {
     }
+
+    /// <summary>
+    /// Gets the list of supported color kinds.
+    /// </summary>
+    public static ColorKind[] AllColorKinds => Enum.GetValues<ColorKind>();
 
     partial void OnOffsetChanged(long value)
     {
@@ -125,6 +135,11 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
     }
 
     partial void OnColorsPerPaletteChanged(int value)
+    {
+        ReadRawPalette();
+    }
+
+    partial void OnColorKindChanged(ColorKind value)
     {
         ReadRawPalette();
     }
@@ -162,7 +177,7 @@ public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
             Offset = Offset,
             Size = Length,
             ColorsPerPalette = ColorsPerPalette,
-            ColorEncoding = Bgr555.Instance,
+            ColorEncoding = ColorKind.GetEncoding(),
         };
         var raw2Palette = new RawBinary2PaletteCollection(options);
 

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteViewModel.cs
@@ -11,7 +11,7 @@ using Texim.Formats;
 using Texim.Palettes;
 using Yarhl.IO;
 
-public partial class BinaryPaletteViewModel : ObservableObject
+public partial class BinaryPaletteViewModel : ObservableObject, IFormatViewModel
 {
     private const int DefaultMaxLength = 256 * 2 * 16;
 
@@ -54,17 +54,17 @@ public partial class BinaryPaletteViewModel : ObservableObject
             random.NextBytes(colorBytes);
             stream = DataStreamFactory.FromArray(colorBytes);
             binaryFormat = new BinaryFormat(stream);
+
+            maximumOffset = 0;
+            length = 512;
+            maximumLength = 512;
+            colorsPerPalette = 16;
         } else {
             stream = null!;
             binaryFormat = null!;
         }
 
         hexBuilder = new StringBuilder();
-
-        maximumOffset = stream.Length - 512;
-        length = 512;
-        maximumLength = (int)stream.Length;
-        colorsPerPalette = 16;
         hexContent = string.Empty;
 
         rawPalettes = new PaletteCollection();
@@ -72,7 +72,9 @@ public partial class BinaryPaletteViewModel : ObservableObject
             IsModelPropertyVisible = false,
         };
 
-        ReadRawPalette();
+        if (Design.IsDesignMode) {
+            ReadRawPalette();
+        }
     }
 
     /// <summary>

--- a/src/SceneGate.UI.Formats/Graphics/ColorKind.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ColorKind.cs
@@ -1,0 +1,45 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using Texim.Colors;
+
+/// <summary>
+/// Color encoding formats.
+/// </summary>
+public enum ColorKind
+{
+    /// <summary>
+    /// BGR 5-bits encoding.
+    /// </summary>
+    BGR555,
+
+    /// <summary>
+    /// RGB 8-bits encoding.
+    /// </summary>
+    RGB32,
+
+    /// <summary>
+    /// RGB 8-bits with alpha encoding.
+    /// </summary>
+    RGBA32,
+}
+
+/// <summary>
+/// Extension methos for the color kind enum.
+/// </summary>
+public static class ColorKindExtensions
+{
+    /// <summary>
+    /// Gets the encoding instance for the color kind.
+    /// </summary>
+    /// <param name="kind">The color kind.</param>
+    /// <returns>Its color encoding instance.</returns>
+    /// <exception cref="NotSupportedException">Unsupported format.</exception>
+    public static IColorEncoding GetEncoding(this ColorKind kind) =>
+        kind switch {
+            ColorKind.BGR555 => Bgr555.Instance,
+            ColorKind.RGB32 => Rgb32.Instance,
+            ColorKind.RGBA32 => Rgba32.Instance,
+            _ => throw new NotSupportedException("Unsupported color kind"),
+        };
+}

--- a/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
@@ -22,6 +22,7 @@
         Margin="5">
 
     <Grid Grid.Row="0" Grid.Column="0"
+          IsVisible="{Binding IsModelPropertyVisible}"
           RowDefinitions="Auto,Auto,1*,Auto,Auto,1*"
           HorizontalAlignment="Left"
           Margin="10 0">

--- a/src/SceneGate.UI.Formats/Graphics/PaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteViewModel.cs
@@ -136,7 +136,11 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
         SelectedHexColor = $"{value.R:X2}{value.G:X2}{value.B:X2}";
     }
 
-    public void UpdatePalettes(IPaletteCollection palettes)
+    /// <summary>
+    /// Replace the current displayed palettes with a new set.
+    /// </summary>
+    /// <param name="palettes">The new set of palettes to display.</param>
+    public void ReplacePalettes(IPaletteCollection palettes)
     {
         Palettes = new (palettes.Palettes.Select((p, idx) => new PaletteRepresentation(idx, p)));
     }

--- a/src/SceneGate.UI.Formats/Graphics/PaletteViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -42,6 +43,9 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
     [ObservableProperty]
     private string? selectedHexColor;
 
+    [ObservableProperty]
+    private bool isModelPropertyVisible;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteViewModel"/> class.
     /// </summary>
@@ -50,22 +54,29 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
     /// </remarks>
     public PaletteViewModel()
     {
-        var random = new Random(42);
-        byte[] colorBytes = new byte[256 * 2];
-        random.NextBytes(colorBytes);
-        Rgb[] colors = colorBytes.DecodeColorsAs<Bgr555>();
+        if (Design.IsDesignMode) {
+            var random = new Random(42);
+            byte[] colorBytes = new byte[256 * 2];
+            random.NextBytes(colorBytes);
+            Rgb[] colors = colorBytes.DecodeColorsAs<Bgr555>();
 
-        IPalette[] testPalettes = [
-            new Palette(colors),
-            new Palette(colors[..128]),
-            new Palette(colors[..16]),
-            new Palette(colors[16..30]),
-            new Palette(colors[0..0]),
-            new Palette(colors[..20]),
-        ];
+            IPalette[] testPalettes = [
+                new Palette(colors),
+                new Palette(colors[..128]),
+                new Palette(colors[..16]),
+                new Palette(colors[16..30]),
+                new Palette(colors[0..0]),
+                new Palette(colors[..20]),
+            ];
 
-        SourceFormat = testPalettes[0];
-        Palettes = new(testPalettes.Select((p, idx) => new PaletteRepresentation(idx, p)));
+            SourceFormat = testPalettes[0];
+            Palettes = new(testPalettes.Select((p, idx) => new PaletteRepresentation(idx, p)));
+        } else {
+            SourceFormat = null!;
+            Palettes = null!;
+        }
+
+        IsModelPropertyVisible = true;
 
         AskOutputFile = new AsyncInteraction<IStorageFile?>();
         AskOutputFolder = new AsyncInteraction<IStorageFolder?>();
@@ -77,12 +88,10 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
     /// </summary>
     /// <param name="palette">The palette to represent.</param>
     public PaletteViewModel(IPalette palette)
+        : this()
     {
         SourceFormat = palette;
         Palettes = [new PaletteRepresentation(0, palette)];
-        AskOutputFile = new AsyncInteraction<IStorageFile?>();
-        AskOutputFolder = new AsyncInteraction<IStorageFolder?>();
-        AskInputFile = new AsyncInteraction<IStorageFile?>();
     }
 
     /// <summary>
@@ -90,12 +99,10 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
     /// </summary>
     /// <param name="palettes">The collection of palettes to represent.</param>
     public PaletteViewModel(IPaletteCollection palettes)
+        : this()
     {
         SourceFormat = palettes;
         Palettes = new(palettes.Palettes.Select((p, idx) => new PaletteRepresentation(idx, p)));
-        AskOutputFile = new AsyncInteraction<IStorageFile?>();
-        AskOutputFolder = new AsyncInteraction<IStorageFolder?>();
-        AskInputFile = new AsyncInteraction<IStorageFile?>();
     }
 
     /// <summary>
@@ -127,6 +134,11 @@ public partial class PaletteViewModel : ObservableObject, IFormatViewModel
     {
         SelectedHsvColor = value.ToHsv();
         SelectedHexColor = $"{value.R:X2}{value.G:X2}{value.B:X2}";
+    }
+
+    public void UpdatePalettes(IPaletteCollection palettes)
+    {
+        Palettes = new (palettes.Palettes.Select((p, idx) => new PaletteRepresentation(idx, p)));
     }
 
     /// <summary>

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
@@ -47,7 +47,8 @@
                 SelectedItem="{Binding SelectedNode}"
                 ItemsSource="{Binding Nodes}"
                 SelectionMode="Single"
-                DoubleTapped="NodeTreeViewDoubleTapped">
+                DoubleTapped="NodeTreeViewDoubleTapped"
+                KeyUp="NodeTreeViewKeyUp">
         <TreeView.ItemTemplate>
           <TreeDataTemplate ItemsSource="{Binding Children}">
             <!-- Setting background so contextmenu works everywhere -->
@@ -74,16 +75,41 @@
                 <fluent:SymbolIcon Symbol="Sync" />
               </Button>
               <Grid.ContextFlyout>
-                <MenuFlyout>
-                  <MenuItem Header="Save to file"
-                            Command="{ReflectionBinding $parent[TreeView].DataContext.SaveBinaryNodeCommand}" />
-                  <MenuItem Header="Convert"
-                            Command="{ReflectionBinding $parent[TreeView].DataContext.ConvertNodeCommand}" />
-                  <MenuItem Header="Show"
-                            Command="{ReflectionBinding $parent[TreeView].DataContext.OpenNodeViewCommand}" />
-                  <MenuItem Header="Copy path"
-                            Command="{ReflectionBinding $parent[TreeView].DataContext.CopyPathCommand}" />
-                </MenuFlyout>
+                <fluent:FAMenuFlyout>
+                  <fluent:MenuFlyoutItem
+                    Text="Copy path"
+                    IconSource="FolderLink"
+                    Command="{ReflectionBinding $parent[TreeView].DataContext.CopyPathCommand}" />
+                  <fluent:MenuFlyoutItem
+                    Text="Save to file"
+                    IconSource="SaveAs"
+                    Command="{ReflectionBinding $parent[TreeView].DataContext.SaveBinaryNodeCommand}" />
+                  <fluent:MenuFlyoutItem
+                    Text="Convert"
+                    IconSource="Sync"
+                    Command="{ReflectionBinding $parent[TreeView].DataContext.ConvertNodeCommand}" />
+                  <fluent:MenuFlyoutItem
+                    Text="Open with default"
+                    IconSource="View"
+                    HotKey="Space"
+                    Command="{ReflectionBinding $parent[TreeView].DataContext.OpenNodeViewCommand}" />
+                  <fluent:MenuFlyoutSubItem Text="Open as...">
+                    <fluent:MenuFlyoutItem Text="Model object"
+                                           IconSource="Code"
+                                           Command="{ReflectionBinding $parent[TreeView].DataContext.OpenAsObjectCommand}"/>
+                    <fluent:MenuFlyoutItem Text="Binary"
+                                           IconSource="Page"
+                                           HotKey="H"
+                                           Command="{ReflectionBinding $parent[TreeView].DataContext.OpenWithHexViewerCommand}"/>
+                    <fluent:MenuFlyoutItem Text="Raw palette"
+                                           IconSource="ColorBackground"
+                                           HotKey="P"
+                                           Command="{ReflectionBinding $parent[TreeView].DataContext.OpenAsRawPaletteCommand}"/>
+                    <fluent:MenuFlyoutItem Text="Raw image"
+                                           IconSource="Image"
+                                           IsEnabled="False" />
+                  </fluent:MenuFlyoutSubItem>
+                </fluent:FAMenuFlyout>
               </Grid.ContextFlyout>
             </Grid>
           </TreeDataTemplate>

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
@@ -91,6 +92,17 @@ public partial class AnalyzeView : UserControl
     private async void ConvertersTreeViewDoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
     {
         await viewModel.ConvertNodeCommand.ExecuteAsync(null);
+    }
+
+    private void NodeTreeViewKeyUp(object? sender, Avalonia.Input.KeyEventArgs e)
+    {
+        if (e.Key == Key.Space && viewModel.OpenNodeViewCommand.CanExecute(null)) {
+            viewModel.OpenNodeViewCommand.Execute(null);
+        } else if (e.Key == Key.H && viewModel.OpenWithHexViewerCommand.CanExecute(null)) {
+            viewModel.OpenWithHexViewerCommand.Execute(null);
+        } else if (e.Key == Key.P && viewModel.OpenAsRawPaletteCommand.CanExecute(null)) {
+            viewModel.OpenAsRawPaletteCommand.Execute(null);
+        }
     }
 
     private async Task<object?> DisplayConversionStarted(NodeConversionInfo info)

--- a/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.Input;
 using SceneGate.UI.ControlsData;
 using SceneGate.UI.Formats;
 using SceneGate.UI.Formats.Common;
+using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Mvvm;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
@@ -162,6 +163,19 @@ public partial class AnalyzeViewModel : ViewModelBase
         return SelectedNode is not null;
     }
 
+    private void OpenNodeViewWith(IFormatViewModel formatViewModel)
+    {
+        TreeGridNode? selection = SelectedNode;
+        if (selection is null) {
+            return;
+        }
+
+        var tab = new NodeFormatTab(selection.Node, selection.Kind, formatViewModel);
+        FormatViewTabs.Add(tab);
+
+        SelectedTab = tab;
+    }
+
     [RelayCommand]
     private void CloseNodeView(NodeFormatTab tab)
     {
@@ -263,6 +277,45 @@ public partial class AnalyzeViewModel : ViewModelBase
 
     private bool CanCopyConverterTypeName() =>
         SelectedConverter is { Kind: TreeGridConverterKind.Converter };
+
+    [RelayCommand(CanExecute = nameof(CanOpenAsObject))]
+    private void OpenAsObject()
+    {
+        if (SelectedNode?.Node.Format is not IFormat format) {
+            return;
+        }
+
+        var viewModel = new ObjectViewModel(format);
+        OpenNodeViewWith(viewModel);
+    }
+
+    private bool CanOpenAsObject() => SelectedNode is not null;
+
+    [RelayCommand(CanExecute = nameof(CanOpenWithHexViewer))]
+    private void OpenWithHexViewer()
+    {
+        if (SelectedNode?.Node.Format is not IBinary format) {
+            return;
+        }
+
+        var viewModel = new HexViewerViewModel(format);
+        OpenNodeViewWith(viewModel);
+    }
+
+    private bool CanOpenWithHexViewer() => SelectedNode?.Node.Format is IBinary;
+
+    [RelayCommand(CanExecute = nameof(CanOpenAsRawPalette))]
+    private void OpenAsRawPalette()
+    {
+        if (SelectedNode?.Node.Format is not IBinary format) {
+            return;
+        }
+
+        var viewModel = new BinaryPaletteViewModel(format);
+        OpenNodeViewWith(viewModel);
+    }
+
+    private bool CanOpenAsRawPalette() => SelectedNode?.Node.Format is IBinary;
 
     partial void OnNodeNameFilterChanged(string? value)
     {


### PR DESCRIPTION
Create a new format view so we can analyze / view binary data (`IBinary`) as a raw palette. It re-use the palette view, removing the properties (as there would be none). The control allows to specify offset, length, colors per palette and color encoding.

It also shows the data that will be processed as palette in hex format.

As there is a default view for `IBinary` (hex viewer), it can be opened via hotkey `P` or context menu in treeview.

Part of #13 

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~~Related documentation is updated~~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Binary formats can be seen as palettes
- The view can be opened

## Follow-up work

None

## Example

![image](https://github.com/SceneGate/SceneGate/assets/3107481/4951e4b1-1b31-4bf3-9095-440b03e6e5d2)

