### PR TITLE
✨ New format view: image viewer for RGB, indexed, screen images and raw image viewer

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="11.0.6" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.6" />
+    <PackageVersion Include="Avalonia.Controls.PanAndZoom" Version="11.0.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.0.6" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.6" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.0.6" />

--- a/src/SceneGate.UI.Formats/Common/ObjectView.axaml
+++ b/src/SceneGate.UI.Formats/Common/ObjectView.axaml
@@ -17,9 +17,7 @@
   <TabControl>
     <TabItem Header="Model">
       <ScrollViewer>
-        <pgc:PropertyGrid SelectedObject="{Binding Model}"
-                          AllowFilter="False"
-                          AllowQuickFilter="False" />
+        <pgc:PropertyGrid SelectedObject="{Binding Model}" Classes="Simple ReadOnly" />
       </ScrollViewer>
     </TabItem>
 

--- a/src/SceneGate.UI.Formats/Common/ObjectViewModel.cs
+++ b/src/SceneGate.UI.Formats/Common/ObjectViewModel.cs
@@ -26,7 +26,7 @@ public partial class ObjectViewModel : ObservableObject, IFormatViewModel
     /// Initializes a new instance of the <see cref="ObjectViewModel"/> class.
     /// </summary>
     public ObjectViewModel()
-        : this(new Po())
+        : this(new PoHeader())
     {
     }
 

--- a/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Texts;
+using Texim.Images;
 using Texim.Palettes;
 using Yarhl.FileFormat;
 using Yarhl.IO;
@@ -25,6 +26,8 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
             IPalette palette => new PaletteViewModel(palette),
             IPaletteCollection palettes => new PaletteViewModel(palettes),
 
+            IFullImage fullImage => new ImageViewModel(fullImage),
+
             _ => throw new NotSupportedException("Invalid format"),
         };
     }
@@ -32,6 +35,6 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
     /// <inheritdoc/>
     public bool CanShow(IFormat format)
     {
-        return format is IBinary or Po or IPalette or IPaletteCollection;
+        return format is IBinary or Po or IPalette or IPaletteCollection or IFullImage;
     }
 }

--- a/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Texts;
+using Texim.Compressions.Nitro;
 using Texim.Images;
 using Texim.Palettes;
 using Yarhl.FileFormat;
@@ -20,6 +21,14 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
     /// <inheritdoc/>
     public IFormatViewModel Build(IFormat format, IReadOnlyDictionary<Type, IFormat> formatsCache)
     {
+        // This line should go in Ekona.UI
+        if (format is IScreenMap map) {
+            return new ImageViewModel(
+                map,
+                (IIndexedImage)formatsCache[typeof(IIndexedImage)],
+                (IPaletteCollection)formatsCache[typeof(IPaletteCollection)]);
+        }
+
         return format switch {
             IBinary binaryFormat => new HexViewerViewModel(binaryFormat.Stream),
 
@@ -40,6 +49,14 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
     /// <inheritdoc/>
     public bool CanShow(IFormat format, IReadOnlyCollection<Type> formatsCache)
     {
+        // This line should go in Ekona.UI
+        bool canShowMapImage = format is IScreenMap
+            && formatsCache.Contains(typeof(IIndexedImage))
+            && formatsCache.Contains(typeof(IPaletteCollection));
+        if (canShowMapImage) {
+            return true;
+        }
+
         if (format is IIndexedImage && formatsCache.Contains(typeof(IPaletteCollection))) {
             return true;
         }

--- a/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/CommonFormatsViewModelBuilder.cs
@@ -1,6 +1,8 @@
 ﻿namespace SceneGate.UI.Formats;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Texts;
@@ -16,7 +18,7 @@ using Yarhl.Media.Text;
 public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
 {
     /// <inheritdoc/>
-    public IFormatViewModel Build(IFormat format)
+    public IFormatViewModel Build(IFormat format, IReadOnlyDictionary<Type, IFormat> formatsCache)
     {
         return format switch {
             IBinary binaryFormat => new HexViewerViewModel(binaryFormat.Stream),
@@ -27,14 +29,21 @@ public class CommonFormatsViewModelBuilder : IFormatViewModelBuilder
             IPaletteCollection palettes => new PaletteViewModel(palettes),
 
             IFullImage fullImage => new ImageViewModel(fullImage),
+            IIndexedImage indexedImage => new ImageViewModel(
+                indexedImage,
+                (IPaletteCollection)formatsCache[typeof(IPaletteCollection)]),
 
             _ => throw new NotSupportedException("Invalid format"),
         };
     }
 
     /// <inheritdoc/>
-    public bool CanShow(IFormat format)
+    public bool CanShow(IFormat format, IReadOnlyCollection<Type> formatsCache)
     {
+        if (format is IIndexedImage && formatsCache.Contains(typeof(IPaletteCollection))) {
+            return true;
+        }
+
         return format is IBinary or Po or IPalette or IPaletteCollection or IFullImage;
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml
@@ -70,7 +70,7 @@
                   Content="Hexadecimal"
                   IsCheckedChanged="OffsetHexCheckboxChecked"/>
 
-        <!-- Length -->
+        <!-- Palettes count -->
         <Border Grid.Row="1" Grid.Column="0"
                 Margin="0 5"
                 Height="32"
@@ -78,27 +78,21 @@
                 BorderBrush="{DynamicResource TextControlBorderBrush}"
                 BorderThickness="1,1,0,1"
                 CornerRadius="4,0,0,4">
-          <TextBlock Text="Length"
+          <TextBlock Text="Number palettes"
                      Padding="5 0"
                      FontWeight="SemiBold"
                      VerticalAlignment="Center" />
         </Border>
         <NumericUpDown Grid.Row="1" Grid.Column="1"
-                       Name="LengthNumericBox"
                        Margin="0 5"
                        CornerRadius="0,4,4,0"
                        FormatString="0"
-                       Value="{Binding Length}"
+                       Value="{Binding PalettesCount}"
                        Minimum="0"
-                       Maximum="{Binding MaximumLength}"
+                       Maximum="{Binding MaximumPalettes}"
                        FontFamily="{StaticResource CaskaydiaFont}"
                        VerticalContentAlignment="Center">
         </NumericUpDown>
-        <CheckBox Grid.Row="1" Grid.Column="2"
-                  Margin="10 5"
-                  IsChecked="False"
-                  Content="Hexadecimal"
-                  IsCheckedChanged="LengthHexCheckboxChecked"/>
 
         <!-- Colors per palette -->
         <Border Grid.Row="2" Grid.Column="0"
@@ -141,6 +135,7 @@
                            CornerRadius="0 4 4 0"
                            SelectedIndex="0"
                            IsEditable="False"
+                           HorizontalAlignment="Stretch"
                            SelectedItem="{Binding ColorKind}"
                            ItemsSource="{Binding AllColorKinds}"/>
       </Grid>

--- a/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/BinaryPaletteView.axaml.cs
@@ -26,15 +26,6 @@ public partial class BinaryPaletteView : UserControl
         RefreshNumericBox(OffsetNumericBox);
     }
 
-    private void LengthHexCheckboxChecked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
-    {
-        var checkbox = sender as CheckBox;
-        LengthNumericBox.TextConverter = (checkbox?.IsChecked ?? false)
-            ? new HexadecimalValueConverter()
-            : null;
-        RefreshNumericBox(LengthNumericBox);
-    }
-
     private void RefreshNumericBox(NumericUpDown box)
     {
         // Due to a bug in Avalonia, it doesn't refresh the text when the converter changes

--- a/src/SceneGate.UI.Formats/Graphics/ColorKind.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ColorKind.cs
@@ -42,4 +42,18 @@ public static class ColorKindExtensions
             ColorKind.RGBA32 => Rgba32.Instance,
             _ => throw new NotSupportedException("Unsupported color kind"),
         };
+
+    /// <summary>
+    /// Gets the number of bytes required to decode a color.
+    /// </summary>
+    /// <param name="kind">The color kind.</param>
+    /// <returns>Number of bytes to decode color.</returns>
+    /// <exception cref="NotSupportedException">Unsupported format.</exception>
+    public static int GetBytesPerColor(this ColorKind kind) =>
+        kind switch {
+            ColorKind.BGR555 => Bgr555.BytesPerColor,
+            ColorKind.RGB32 => Rgb32.BytesPerColor,
+            ColorKind.RGBA32 => Rgba32.BytesPerColor,
+            _ => throw new NotSupportedException("Unsupported color kind"),
+        };
 }

--- a/src/SceneGate.UI.Formats/Graphics/DesignImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/DesignImageViewModel.cs
@@ -1,0 +1,46 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using Texim.Colors;
+using Texim.Palettes;
+
+using Yarhl.IO;
+
+/// <summary>
+/// Design view model for ImageView.
+/// </summary>
+public class DesignImageViewModel : ImageViewModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DesignImageViewModel"/> class.
+    /// </summary>
+    public DesignImageViewModel()
+        : base(CreateRandomBinaryImage(), CreateRandomPalettes())
+    {
+    }
+
+    private static IBinary CreateRandomBinaryImage()
+    {
+        byte[] bytes = new byte[256 * 192 * 4];
+        var random = new Random(42);
+        random.NextBytes(bytes);
+
+        return new BinaryFormat(DataStreamFactory.FromArray(bytes));
+    }
+
+    private static IPaletteCollection CreateRandomPalettes()
+    {
+        byte[] bytes = new byte[256 * 2 * 4];
+        var random = new Random(42);
+        random.NextBytes(bytes);
+
+        Rgb[] colors = bytes.DecodeColorsAs<Bgr555>();
+        IPalette[] palettes = [
+            new Palette(colors[..256]),
+            new Palette(colors[256..512]),
+            new Palette(colors[512..768]),
+            new Palette(colors[768..]),
+        ];
+        return new PaletteCollection(palettes);
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/DesignRawImageOptionsViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/DesignRawImageOptionsViewModel.cs
@@ -1,0 +1,27 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using Yarhl.IO;
+
+/// <summary>
+/// Design model for <see cref="RawImageOptionsViewModel"/>.
+/// </summary>
+public class DesignRawImageOptionsViewModel : RawImageOptionsViewModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DesignRawImageOptionsViewModel"/> class.
+    /// </summary>
+    public DesignRawImageOptionsViewModel()
+        : base(CreateRandomBinaryImage())
+    {
+    }
+
+    private static IBinary CreateRandomBinaryImage()
+    {
+        byte[] bytes = new byte[256 * 192 * 4];
+        var random = new Random(42);
+        random.NextBytes(bytes);
+
+        return new BinaryFormat(DataStreamFactory.FromArray(bytes));
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -70,15 +70,20 @@
       </SplitView.Pane>
     </SplitView>
 
-    <fluent:CommandBar Grid.Row="0" HorizontalAlignment="Center">
+    <fluent:CommandBar Grid.Row="0"
+                       HorizontalAlignment="Center"
+                       DefaultLabelPosition="Bottom">
       <fluent:CommandBar.PrimaryCommands>
-        <fluent:CommandBarButton Label="Save"
-                                 IconSource="Save"
-                                 Command="{Binding SaveImageCommand}"/>
         <fluent:CommandBarToggleButton Name="InfoToggleButton"
                                        Label="Object info"
                                        IconSource="Tag"
                                        IsChecked="True" />
+        <fluent:CommandBarButton Label="Save"
+                                 IconSource="Save"
+                                 Command="{Binding SaveImageCommand}"/>
+        <fluent:CommandBarButton Label="Import"
+                                 IconSource="Upload"
+                                 IsEnabled="False"/>
         <fluent:CommandBarButton Label="Zoom out"
                                  IconSource="ZoomOut"
                                  Click="ZoomOutClick" />

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -21,13 +21,14 @@
 
       <ScrollViewer HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto"
-                    Padding="0 0 20 20"
-                    PointerWheelChanged="ScrollViewerPointerWheelChanged">
+                    Name="ImageScrollViewer"
+                    Padding="0 0 20 20">
         <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
                 BorderThickness="1"
                 Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
                 HorizontalAlignment="Center"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                PointerWheelChanged="ZoomingPointerWheelChanged">
           <Image Source="{Binding Bitmap}"
                  Width="{Binding Width}"
                  Height="{Binding Height}" />

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -10,7 +10,7 @@
              x:Class="SceneGate.UI.Formats.Graphics.ImageView"
              x:DataType="local:ImageViewModel">
   <Design.DataContext>
-    <local:ImageViewModel />
+    <local:DesignImageViewModel />
   </Design.DataContext>
 
   <Grid RowDefinitions="Auto,*">
@@ -56,7 +56,7 @@
                 BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
                 Background="{DynamicResource ControlFillColorDefaultBrush}"
                 CornerRadius="4 0 0 0">
-          <Grid RowDefinitions="Auto,*" Margin="10">
+          <Grid RowDefinitions="Auto,*" Margin="5">
             <DockPanel Margin="5 0 0 0">
               <ToggleButton DockPanel.Dock="Right"
                             Theme="{StaticResource TransparentButton}"
@@ -72,7 +72,13 @@
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Auto"
                           Margin="0 10 0 0" >
-              <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}" Classes="Simple ReadOnly" />
+              <Panel>
+                <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
+                                  Classes="Simple ReadOnly"
+                                  IsVisible="{Binding !IsRawImage}"/>
+                <local:RawImageOptionsView DataContext="{Binding RawImageOptions}"
+                                           IsVisible="{ReflectionBinding $parent.DataContext.IsRawImage}"/>
+              </Panel>
             </ScrollViewer>
           </Grid>
         </Border>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -18,10 +18,21 @@
                PanePlacement="Right"
                OpenPaneLength="400"
                DisplayMode="Inline">
- 
-      <Image Source="{Binding Bitmap}"
-             Width="{Binding Width}"
-             Height="{Binding Height}" />
+
+      <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Auto"
+                    Padding="0 0 20 20"
+                    PointerWheelChanged="ScrollViewer_PointerWheelChanged">
+        <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+          <Image Source="{Binding Bitmap}"
+                 Width="{Binding Width}"
+                 Height="{Binding Height}" />
+        </Border>
+      </ScrollViewer>
 
       <SplitView.Pane>
         <Border BorderThickness="2 2 0 0"
@@ -55,10 +66,17 @@
                                        Label="Object info"
                                        IconSource="Tag"
                                        IsChecked="True" />
-        <fluent:CommandBarButton Label="Zoom in" IconSource="ZoomOut" />
-        <fluent:CommandBarButton Label="Zoom out" IconSource="ZoomIn" />
+        <fluent:CommandBarButton Label="Zoom out"
+                                 IconSource="ZoomOut"
+                                 Command="{Binding ZoomOutCommand}" />
+        <fluent:CommandBarButton Label="Zoom in"
+                                 IconSource="ZoomIn"
+                                 Command="{Binding ZoomInCommand}" />
         <fluent:CommandBarElementContainer VerticalAlignment="Center">
-          <TextBlock Text="100%" VerticalAlignment="Center" />
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="{Binding Zoom}" />
+            <TextBlock Text=" %" />
+          </StackPanel>
         </fluent:CommandBarElementContainer>
       </fluent:CommandBar.PrimaryCommands>
     </fluent:CommandBar>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -38,8 +38,6 @@
                   HorizontalAlignment="Center"
                   VerticalAlignment="Center">
             <Image Source="{Binding Bitmap}"
-                   Width="{Binding Width}"
-                   Height="{Binding Height}"
                    Stretch="None"/>
           </Border>
         </paz:ZoomBorder>
@@ -97,7 +95,7 @@
                                        IconSource="ColorBackground"
                                        Label="Palette"
                                        IsChecked="True"
-                                       IsVisible="{Binding IsIndexedImage}" />
+                                       IsVisible="{Binding CanShowPalette}" />
         <fluent:CommandBarToggleButton Name="InfoToggleButton"
                                        Label="Info"
                                        IconSource="Tag"

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -22,7 +22,7 @@
       <ScrollViewer HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto"
                     Padding="0 0 20 20"
-                    PointerWheelChanged="ScrollViewer_PointerWheelChanged">
+                    PointerWheelChanged="ScrollViewerPointerWheelChanged">
         <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
                 BorderThickness="1"
                 Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
@@ -61,7 +61,9 @@
 
     <fluent:CommandBar Grid.Row="0" HorizontalAlignment="Center">
       <fluent:CommandBar.PrimaryCommands>
-        <fluent:CommandBarButton Label="Save" IconSource="Save" />
+        <fluent:CommandBarButton Label="Save"
+                                 IconSource="Save"
+                                 Command="{Binding SaveImageCommand}"/>
         <fluent:CommandBarToggleButton Name="InfoToggleButton"
                                        Label="Object info"
                                        IconSource="Tag"
@@ -72,7 +74,9 @@
         <fluent:CommandBarButton Label="Zoom in"
                                  IconSource="ZoomIn"
                                  Command="{Binding ZoomInCommand}" />
-        <fluent:CommandBarElementContainer VerticalAlignment="Center">
+        <fluent:CommandBarElementContainer VerticalAlignment="Center"
+                                           DoubleTapped="ZoomLabelDoubleTapped"
+                                           ToolTip.Tip="Double click to restore zoom">
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="{Binding Zoom}" />
             <TextBlock Text=" %" />

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -72,9 +72,7 @@
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Auto"
                           Margin="0 10 0 0" >
-              <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
-                                AllowFilter="False"
-                                AllowQuickFilter="False" />
+              <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}" Classes="Simple ReadOnly" />
             </ScrollViewer>
           </Grid>
         </Border>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -1,0 +1,66 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:fluent="using:FluentAvalonia.UI.Controls"
+             xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
+             xmlns:local="using:SceneGate.UI.Formats.Graphics"
+             mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="600"
+             x:Class="SceneGate.UI.Formats.Graphics.ImageView"
+             x:DataType="local:ImageViewModel">
+  <Design.DataContext>
+    <local:ImageViewModel />
+  </Design.DataContext>
+
+  <Grid RowDefinitions="Auto,*">
+    <SplitView Grid.Row="1"
+               IsPaneOpen="{Binding IsChecked, ElementName=InfoToggleButton}"
+               PanePlacement="Right"
+               OpenPaneLength="400"
+               DisplayMode="Inline">
+ 
+      <Image Source="{Binding Bitmap}"
+             Width="{Binding Width}"
+             Height="{Binding Height}" />
+
+      <SplitView.Pane>
+        <Border BorderThickness="2 2 0 0"
+                BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+                Background="{DynamicResource ControlFillColorDefaultBrush}"
+                CornerRadius="4 0 0 0">
+          <StackPanel Orientation="Vertical" Spacing="10" Margin="10">
+            <DockPanel Margin="5 0 0 0">
+              <ToggleButton DockPanel.Dock="Right"
+                            Theme="{StaticResource TransparentButton}"
+                            FontSize="20"
+                            IsChecked="{Binding IsChecked, ElementName=InfoToggleButton}">
+                <fluent:SymbolIcon Symbol="Cancel" />
+              </ToggleButton>
+              <TextBlock Text="Info"
+                         Theme="{StaticResource TitleTextBlockStyle}"/>
+            </DockPanel>
+            <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
+                              Margin="0 10 0 0"
+                              AllowFilter="False"
+                              AllowQuickFilter="False" />
+          </StackPanel>
+        </Border>
+      </SplitView.Pane>
+    </SplitView>
+
+    <fluent:CommandBar Grid.Row="0" HorizontalAlignment="Center">
+      <fluent:CommandBar.PrimaryCommands>
+        <fluent:CommandBarButton Label="Save" IconSource="Save" />
+        <fluent:CommandBarToggleButton Name="InfoToggleButton"
+                                       Label="Object info"
+                                       IconSource="Tag"
+                                       IsChecked="True" />
+        <fluent:CommandBarButton Label="Zoom in" IconSource="ZoomOut" />
+        <fluent:CommandBarButton Label="Zoom out" IconSource="ZoomIn" />
+        <fluent:CommandBarElementContainer VerticalAlignment="Center">
+          <TextBlock Text="100%" VerticalAlignment="Center" />
+        </fluent:CommandBarElementContainer>
+      </fluent:CommandBar.PrimaryCommands>
+    </fluent:CommandBar>
+  </Grid>
+</UserControl>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -13,6 +13,10 @@
     <local:DesignImageViewModel />
   </Design.DataContext>
 
+  <UserControl.Resources>
+    <StreamGeometry x:Key="document_error_regular">M18.5 20C18.5 20.275 18.276 20.5 18 20.5H12.2678C11.9806 21.051 11.6168 21.5557 11.1904 22H18C19.104 22 20 21.104 20 20V9.828C20 9.298 19.789 8.789 19.414 8.414L13.585 2.586C13.57 2.57105 13.5531 2.55808 13.5363 2.5452C13.5238 2.53567 13.5115 2.5262 13.5 2.516C13.429 2.452 13.359 2.389 13.281 2.336C13.2557 2.31894 13.2281 2.30548 13.2005 2.29207C13.1845 2.28426 13.1685 2.27647 13.153 2.268C13.1363 2.25859 13.1197 2.24897 13.103 2.23933C13.0488 2.20797 12.9944 2.17648 12.937 2.152C12.74 2.07 12.528 2.029 12.313 2.014C12.2933 2.01274 12.2738 2.01008 12.2542 2.00741C12.2271 2.00371 12.1999 2 12.172 2H6C4.896 2 4 2.896 4 4V11.4982C4.47417 11.3004 4.97679 11.1572 5.5 11.0764V4C5.5 3.725 5.724 3.5 6 3.5H12V8C12 9.104 12.896 10 14 10H18.5V20ZM13.5 4.621L17.378 8.5H14C13.724 8.5 13.5 8.275 13.5 8V4.621Z M12 17.5C12 20.5376 9.53757 23 6.5 23C3.46243 23 1 20.5376 1 17.5C1 14.4624 3.46243 12 6.5 12C9.53757 12 12 14.4624 12 17.5ZM6.5 14C6.22386 14 6 14.2239 6 14.5V18.5C6 18.7761 6.22386 19 6.5 19C6.77614 19 7 18.7761 7 18.5V14.5C7 14.2239 6.77614 14 6.5 14ZM6.5 21.125C6.84518 21.125 7.125 20.8452 7.125 20.5C7.125 20.1548 6.84518 19.875 6.5 19.875C6.15482 19.875 5.875 20.1548 5.875 20.5C5.875 20.8452 6.15482 21.125 6.5 21.125Z</StreamGeometry>
+  </UserControl.Resources>
+
   <Grid RowDefinitions="Auto,*">
     <SplitView Grid.Row="1"
                IsPaneOpen="{Binding IsChecked, ElementName=InfoToggleButton}"
@@ -39,14 +43,19 @@
             </fluent:FAMenuFlyout>
           </paz:ZoomBorder.ContextFlyout>
 
-          <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
-                  BorderThickness="1"
-                  Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Center">
-            <Image Source="{Binding Bitmap}"
-                   Stretch="None"/>
-          </Border>
+          <Panel>
+            <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsVisible="{Binding Bitmap, Converter={x:Static ObjectConverters.IsNotNull}}">
+              <Image Source="{Binding Bitmap}"
+                     Stretch="None"/>
+            </Border>
+            <PathIcon Data="{StaticResource document_error_regular}"
+                      IsVisible="{Binding Bitmap, Converter={x:Static ObjectConverters.IsNull}}"/>
+          </Panel>
 
         </paz:ZoomBorder>
       </ScrollViewer>
@@ -68,18 +77,17 @@
               <TextBlock Text="Info"
                          Theme="{StaticResource TitleTextBlockStyle}"/>
             </DockPanel>
-            <ScrollViewer Grid.Row="1"
-                          VerticalScrollBarVisibility="Auto"
-                          HorizontalScrollBarVisibility="Auto"
-                          Margin="0 10 0 0" >
-              <Panel>
+            <Panel Grid.Row="1">
+              <ScrollViewer VerticalScrollBarVisibility="Auto"
+                            HorizontalScrollBarVisibility="Auto"
+                            IsVisible="{Binding !IsRawImage}"
+                            Margin="0 10 0 0" >
                 <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
-                                  Classes="Simple ReadOnly"
-                                  IsVisible="{Binding !IsRawImage}"/>
-                <local:RawImageOptionsView DataContext="{Binding RawImageOptions}"
-                                           IsVisible="{ReflectionBinding $parent.DataContext.IsRawImage}"/>
-              </Panel>
-            </ScrollViewer>
+                                  Classes="Simple ReadOnly" />
+              </ScrollViewer>
+              <local:RawImageOptionsView DataContext="{Binding RawImageOptions}"
+                                          IsVisible="{ReflectionBinding $parent.DataContext.IsRawImage}"/>
+            </Panel>
           </Grid>
         </Border>
       </SplitView.Pane>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:fluent="using:FluentAvalonia.UI.Controls"
+             xmlns:paz="using:Avalonia.Controls.PanAndZoom"
              xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
              xmlns:local="using:SceneGate.UI.Formats.Graphics"
              mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="600"
@@ -16,23 +17,32 @@
     <SplitView Grid.Row="1"
                IsPaneOpen="{Binding IsChecked, ElementName=InfoToggleButton}"
                PanePlacement="Right"
-               OpenPaneLength="400"
+               OpenPaneLength="350"
                DisplayMode="Inline">
 
       <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                    VerticalScrollBarVisibility="Auto"
-                    Name="ImageScrollViewer"
-                    Padding="0 0 20 20">
-        <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                PointerWheelChanged="ZoomingPointerWheelChanged">
-          <Image Source="{Binding Bitmap}"
-                 Width="{Binding Width}"
-                 Height="{Binding Height}" />
-        </Border>
+                    VerticalScrollBarVisibility="Auto">
+        <paz:ZoomBorder Name="ZoomImageBorder"
+                        VerticalAlignment="Stretch"
+                        HorizontalAlignment="Stretch"
+                        Stretch="None"
+                        ZoomSpeed="1.2"
+                        ClipToBounds="True"
+                        Focusable="True"
+                        EnablePan="True"
+                        PanButton="Left"
+                        EnableZoom="True">
+          <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center">
+            <Image Source="{Binding Bitmap}"
+                   Width="{Binding Width}"
+                   Height="{Binding Height}"
+                   Stretch="None"/>
+          </Border>
+        </paz:ZoomBorder>
       </ScrollViewer>
 
       <SplitView.Pane>
@@ -71,16 +81,17 @@
                                        IsChecked="True" />
         <fluent:CommandBarButton Label="Zoom out"
                                  IconSource="ZoomOut"
-                                 Command="{Binding ZoomOutCommand}" />
+                                 Click="ZoomOutClick" />
         <fluent:CommandBarButton Label="Zoom in"
                                  IconSource="ZoomIn"
-                                 Command="{Binding ZoomInCommand}" />
+                                 Click="ZoomInClick" />
         <fluent:CommandBarElementContainer VerticalAlignment="Center"
                                            DoubleTapped="ZoomLabelDoubleTapped"
                                            ToolTip.Tip="Double click to restore zoom">
           <StackPanel Orientation="Horizontal">
-            <TextBlock Text="{Binding Zoom}" />
-            <TextBlock Text=" %" />
+            <TextBlock Text="Zoom: " />
+            <TextBlock Text="{Binding ZoomX, ElementName=ZoomImageBorder, StringFormat={}{0:F2}}"
+                       Width="40"/>
           </StackPanel>
         </fluent:CommandBarElementContainer>
       </fluent:CommandBar.PrimaryCommands>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -17,7 +17,7 @@
     <SplitView Grid.Row="1"
                IsPaneOpen="{Binding IsChecked, ElementName=InfoToggleButton}"
                PanePlacement="Right"
-               OpenPaneLength="350"
+               OpenPaneLength="410"
                DisplayMode="Inline">
 
       <ScrollViewer HorizontalScrollBarVisibility="Auto"
@@ -50,32 +50,56 @@
                 BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
                 Background="{DynamicResource ControlFillColorDefaultBrush}"
                 CornerRadius="4 0 0 0">
-          <StackPanel Orientation="Vertical" Spacing="10" Margin="10">
+          <Grid RowDefinitions="Auto,*" Margin="10">
             <DockPanel Margin="5 0 0 0">
               <ToggleButton DockPanel.Dock="Right"
                             Theme="{StaticResource TransparentButton}"
                             FontSize="20"
+                            ToolTip.Tip="Close"
                             IsChecked="{Binding IsChecked, ElementName=InfoToggleButton}">
                 <fluent:SymbolIcon Symbol="Cancel" />
               </ToggleButton>
               <TextBlock Text="Info"
                          Theme="{StaticResource TitleTextBlockStyle}"/>
             </DockPanel>
-            <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
-                              Margin="0 10 0 0"
-                              AllowFilter="False"
-                              AllowQuickFilter="False" />
-          </StackPanel>
+            <ScrollViewer Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Auto"
+                          Margin="0 10 0 0">
+              <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
+                                AllowFilter="False"
+                                AllowQuickFilter="False" />
+            </ScrollViewer>
+          </Grid>
         </Border>
       </SplitView.Pane>
     </SplitView>
 
+    <Border Grid.Row="1"
+            BorderThickness="2"
+            BorderBrush="{DynamicResource AccentFillColorDefaultBrush}"
+            Background="{DynamicResource ControlFillColorDefaultBrush}"
+            CornerRadius="4"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Bottom"
+            IsVisible="{Binding IsChecked, ElementName=ShowPaletteButton}"
+            Margin="10"
+            Padding="10">
+        <Image Source="{Binding PaletteImage}"
+               Stretch="None"/>
+    </Border>
+    
     <fluent:CommandBar Grid.Row="0"
                        HorizontalAlignment="Center"
-                       DefaultLabelPosition="Bottom">
+                       DefaultLabelPosition="Right">
       <fluent:CommandBar.PrimaryCommands>
+        <fluent:CommandBarToggleButton Name="ShowPaletteButton"
+                                       IconSource="ColorBackground"
+                                       Label="Palette"
+                                       IsChecked="True"
+                                       IsVisible="{Binding IsIndexedImage}" />
         <fluent:CommandBarToggleButton Name="InfoToggleButton"
-                                       Label="Object info"
+                                       Label="Info"
                                        IconSource="Tag"
                                        IsChecked="True" />
         <fluent:CommandBarButton Label="Save"
@@ -84,18 +108,22 @@
         <fluent:CommandBarButton Label="Import"
                                  IconSource="Upload"
                                  IsEnabled="False"/>
-        <fluent:CommandBarButton Label="Zoom out"
-                                 IconSource="ZoomOut"
+        <fluent:CommandBarButton IconSource="ZoomOut"
                                  Click="ZoomOutClick" />
-        <fluent:CommandBarButton Label="Zoom in"
-                                 IconSource="ZoomIn"
+        <fluent:CommandBarButton IconSource="ZoomIn"
                                  Click="ZoomInClick" />
         <fluent:CommandBarElementContainer VerticalAlignment="Center"
                                            DoubleTapped="ZoomLabelDoubleTapped"
                                            ToolTip.Tip="Double click to restore zoom">
           <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Zoom: " />
+            <TextBlock Text="Zoom: "
+                       FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                       FontSize="12"
+                       VerticalAlignment="Center" />
             <TextBlock Text="{Binding ZoomX, ElementName=ZoomImageBorder, StringFormat={}{0:F2}}"
+                       FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                       FontSize="12"
+                       VerticalAlignment="Center"
                        Width="40"/>
           </StackPanel>
         </fluent:CommandBarElementContainer>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml
@@ -32,6 +32,13 @@
                         EnablePan="True"
                         PanButton="Left"
                         EnableZoom="True">
+          <paz:ZoomBorder.ContextFlyout>
+            <fluent:FAMenuFlyout>
+              <!-- Avalonia doesn't support yet copying images to clipboard -->
+              <fluent:MenuFlyoutItem Text="Copy image" IconSource="Copy" IsVisible="False" />
+            </fluent:FAMenuFlyout>
+          </paz:ZoomBorder.ContextFlyout>
+
           <Border BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
                   BorderThickness="1"
                   Background="{StaticResource ColorControlCheckeredBackgroundBrush}"
@@ -40,6 +47,7 @@
             <Image Source="{Binding Bitmap}"
                    Stretch="None"/>
           </Border>
+
         </paz:ZoomBorder>
       </ScrollViewer>
 
@@ -63,7 +71,7 @@
             <ScrollViewer Grid.Row="1"
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Auto"
-                          Margin="0 10 0 0">
+                          Margin="0 10 0 0" >
               <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
                                 AllowFilter="False"
                                 AllowQuickFilter="False" />
@@ -80,9 +88,14 @@
             CornerRadius="4"
             HorizontalAlignment="Left"
             VerticalAlignment="Bottom"
-            IsVisible="{Binding IsChecked, ElementName=ShowPaletteButton}"
             Margin="10"
             Padding="10">
+      <Border.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding ElementName="ShowPaletteButton" Path="IsChecked" />
+          <Binding Path="IsSinglePalette" />
+        </MultiBinding>
+      </Border.IsVisible>
         <Image Source="{Binding PaletteImage}"
                Stretch="None"/>
     </Border>
@@ -95,17 +108,19 @@
                                        IconSource="ColorBackground"
                                        Label="Palette"
                                        IsChecked="True"
-                                       IsVisible="{Binding CanShowPalette}" />
+                                       IsEnabled="{Binding IsSinglePalette}" />
         <fluent:CommandBarToggleButton Name="InfoToggleButton"
                                        Label="Info"
                                        IconSource="Tag"
                                        IsChecked="True" />
+        <fluent:CommandBarSeparator />
         <fluent:CommandBarButton Label="Save"
                                  IconSource="Save"
                                  Command="{Binding SaveImageCommand}"/>
         <fluent:CommandBarButton Label="Import"
                                  IconSource="Upload"
                                  IsEnabled="False"/>
+        <fluent:CommandBarSeparator />
         <fluent:CommandBarButton IconSource="ZoomOut"
                                  Click="ZoomOutClick" />
         <fluent:CommandBarButton IconSource="ZoomIn"
@@ -125,7 +140,32 @@
                        Width="40"/>
           </StackPanel>
         </fluent:CommandBarElementContainer>
+        <fluent:CommandBarSeparator />
       </fluent:CommandBar.PrimaryCommands>
+
+      <fluent:CommandBar.SecondaryCommands>
+        <fluent:CommandBarToggleButton Label="Use first color for alpha"
+                                       IconSource="View"
+                                       IsEnabled="{Binding IsSinglePalette}"
+                                       IsChecked="{Binding IsFirstColorTransparent}" />
+        <fluent:CommandBarSeparator />
+        <fluent:CommandBarToggleButton Label="Use all palettes"
+                                       IconSource="ColorBackgroundFilled"
+                                       IsEnabled="{Binding CanChangeToMultiPalette}"
+                                       IsChecked="{Binding !IsSinglePalette}" />
+        <fluent:CommandBarElementContainer IsEnabled="{Binding IsSinglePalette}">
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
+            <TextBlock Text="Palette: "
+                       VerticalAlignment="Center" />
+            <fluent:NumberBox Value="{Binding PaletteIndex}"
+                              Margin="5 0"
+                              SpinButtonPlacementMode="Compact"
+                              Width="85"
+                              Minimum="0"
+                              Maximum="{Binding MaximumPaletteIndex}" />
+          </StackPanel>
+        </fluent:CommandBarElementContainer>
+      </fluent:CommandBar.SecondaryCommands>
     </fluent:CommandBar>
   </Grid>
 </UserControl>

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -29,6 +29,7 @@ public partial class ImageView : UserControl
             return;
         }
 
+        ShowPaletteButton.IsChecked = ViewModel.IsIndexedImage;
         ViewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
     }
 

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -2,10 +2,33 @@
 
 using Avalonia.Controls;
 
+/// <summary>
+/// View for Yarhl images.
+/// </summary>
 public partial class ImageView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageView"/> class.
+    /// </summary>
     public ImageView()
     {
         InitializeComponent();
+    }
+
+    private ImageViewModel? ViewModel => DataContext as ImageViewModel;
+
+    private void ScrollViewer_PointerWheelChanged(object? sender, Avalonia.Input.PointerWheelEventArgs e)
+    {
+        if (e.Delta.X != 0) {
+            return;
+        }
+
+        if (e.Delta.Y > 0 && (ViewModel?.CanZoomIn() ?? false)) {
+            ViewModel.ZoomIn();
+        }
+
+        if (e.Delta.Y < 0 && (ViewModel?.CanZoomOut() ?? false)) {
+            ViewModel.ZoomOut();
+        }
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -32,35 +32,19 @@ public partial class ImageView : UserControl
         ViewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
     }
 
-    private void ZoomingPointerWheelChanged(object? sender, Avalonia.Input.PointerWheelEventArgs e)
-    {
-        if (e.Delta.X != 0) {
-            return;
-        }
-
-        // Only with Control pressed
-        if (!e.KeyModifiers.HasFlag(Avalonia.Input.KeyModifiers.Control)) {
-            return;
-        }
-
-        if (e.Delta.Y > 0 && (ViewModel?.CanZoomIn() ?? false)) {
-            ViewModel.ZoomIn();
-
-            e.PreventGestureRecognition();
-        }
-
-        if (e.Delta.Y < 0 && (ViewModel?.CanZoomOut() ?? false)) {
-            ViewModel.ZoomOut();
-
-            e.PreventGestureRecognition();
-        }
-    }
-
     private void ZoomLabelDoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
     {
-        if (ViewModel is not null) {
-            ViewModel.Zoom = 100;
-        }
+        ZoomImageBorder.ResetMatrix();
+    }
+
+    private void ZoomInClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        ZoomImageBorder.ZoomIn();
+    }
+
+    private void ZoomOutClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        ZoomImageBorder.ZoomOut();
     }
 
     private async Task<IStorageFile?> AskOutputFileAsync()

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -29,7 +29,7 @@ public partial class ImageView : UserControl
             return;
         }
 
-        ShowPaletteButton.IsChecked = ViewModel.IsIndexedImage;
+        ShowPaletteButton.IsChecked = ViewModel.CanShowPalette;
         ViewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
     }
 

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -1,0 +1,11 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using Avalonia.Controls;
+
+public partial class ImageView : UserControl
+{
+    public ImageView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -32,18 +32,27 @@ public partial class ImageView : UserControl
         ViewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
     }
 
-    private void ScrollViewerPointerWheelChanged(object? sender, Avalonia.Input.PointerWheelEventArgs e)
+    private void ZoomingPointerWheelChanged(object? sender, Avalonia.Input.PointerWheelEventArgs e)
     {
         if (e.Delta.X != 0) {
             return;
         }
 
+        // Only with Control pressed
+        if (!e.KeyModifiers.HasFlag(Avalonia.Input.KeyModifiers.Control)) {
+            return;
+        }
+
         if (e.Delta.Y > 0 && (ViewModel?.CanZoomIn() ?? false)) {
             ViewModel.ZoomIn();
+
+            e.PreventGestureRecognition();
         }
 
         if (e.Delta.Y < 0 && (ViewModel?.CanZoomOut() ?? false)) {
             ViewModel.ZoomOut();
+
+            e.PreventGestureRecognition();
         }
     }
 
@@ -60,7 +69,7 @@ public partial class ImageView : UserControl
             Title = "Select where to save the file",
             ShowOverwritePrompt = true,
             FileTypeChoices = new[] {
-                FilePickerFileTypes.ImageAll,
+                FilePickerFileTypes.ImagePng,
             },
         };
 

--- a/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageView.axaml.cs
@@ -3,6 +3,9 @@
 using System;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 
 /// <summary>
@@ -29,21 +32,22 @@ public partial class ImageView : UserControl
             return;
         }
 
-        ShowPaletteButton.IsChecked = ViewModel.CanShowPalette;
+        ShowPaletteButton.IsChecked = ViewModel.IsSinglePalette; // initial value, then binded
         ViewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
+        ViewModel.CopyImageToClipboard.RegisterHandler(CopyImageToClipboardAsync);
     }
 
-    private void ZoomLabelDoubleTapped(object? sender, Avalonia.Input.TappedEventArgs e)
+    private void ZoomLabelDoubleTapped(object? sender, TappedEventArgs e)
     {
         ZoomImageBorder.ResetMatrix();
     }
 
-    private void ZoomInClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private void ZoomInClick(object? sender, RoutedEventArgs e)
     {
         ZoomImageBorder.ZoomIn();
     }
 
-    private void ZoomOutClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private void ZoomOutClick(object? sender, RoutedEventArgs e)
     {
         ZoomImageBorder.ZoomOut();
     }
@@ -62,5 +66,10 @@ public partial class ImageView : UserControl
             .StorageProvider
             .SaveFilePickerAsync(options)
             .ConfigureAwait(false);
+    }
+
+    private Task<object?> CopyImageToClipboardAsync(Bitmap image)
+    {
+        throw new NotSupportedException("https://github.com/AvaloniaUI/Avalonia/issues/3588");
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -1,0 +1,83 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Texim.Colors;
+using Texim.Formats;
+using Texim.Images;
+using Yarhl.FileFormat;
+using Yarhl.IO;
+
+public partial class ImageViewModel : ObservableObject, IFormatViewModel
+{
+    [ObservableProperty]
+    private IFullImage image;
+
+    [ObservableProperty]
+    private IFormat sourceFormat;
+
+    [ObservableProperty]
+    private Bitmap? bitmap;
+
+    [ObservableProperty]
+    private int width;
+
+    [ObservableProperty]
+    private int height;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
+    /// </summary>
+    public ImageViewModel()
+    {
+        if (Design.IsDesignMode) {
+            byte[] bytes = new byte[256 * 192 * 4];
+            var random = new Random(42);
+            random.NextBytes(bytes);
+            Rgb[] pixels = bytes.DecodeColorsAs<Rgb32>();
+
+            Image = new FullImage(256, 192) { Pixels = pixels };
+        } else {
+            image = null!;
+            sourceFormat = null!;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
+    /// </summary>
+    /// <param name="fullImage">Image to display.</param>
+    public ImageViewModel(IFullImage fullImage)
+        : this()
+    {
+        Image = fullImage;
+    }
+
+    partial void OnImageChanged(IFullImage value)
+    {
+        SourceFormat = value;
+        Width = value.Width;
+        Height = value.Height;
+        UpdateImage();
+    }
+
+    private void UpdateImage()
+    {
+        ConvertToBitmap();
+    }
+
+    private void ConvertToBitmap()
+    {
+        var converter = new FullImage2Bitmap();
+        using BinaryFormat binaryPng = converter.Convert(Image);
+
+        binaryPng.Stream.Position = 0;
+        Bitmap = new Bitmap(binaryPng.Stream);
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -20,10 +20,6 @@ using Yarhl.IO;
 /// </summary>
 public partial class ImageViewModel : ObservableObject, IFormatViewModel
 {
-    private const int MinZoom = 50;
-    private const int MaxZoom = 10_000;
-    private const double ZoomDelta = 1.1; // 10%
-
     [ObservableProperty]
     private IFullImage image;
 
@@ -33,24 +29,11 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     [ObservableProperty]
     private Bitmap? bitmap;
 
-    [ObservableProperty]
-    private int width;
-
-    [ObservableProperty]
-    private int height;
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(ZoomInCommand))]
-    [NotifyCanExecuteChangedFor(nameof(ZoomOutCommand))]
-    private int zoom;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
     /// </summary>
     public ImageViewModel()
     {
-        zoom = 100;
-
         if (Design.IsDesignMode) {
             byte[] bytes = new byte[256 * 192 * 4];
             var random = new Random(42);
@@ -83,38 +66,6 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     public AsyncInteraction<IStorageFile?> AskOutputFile { get; }
 
     /// <summary>
-    /// Zoom in the image.
-    /// </summary>
-    [RelayCommand(CanExecute = nameof(CanZoomIn))]
-    public void ZoomIn()
-    {
-        double newZoom = Math.Round(Zoom * ZoomDelta);
-        Zoom = (int)Math.Clamp(newZoom, MinZoom, MaxZoom);
-    }
-
-    /// <summary>
-    /// Gets a value indicating if the image can zoom in.
-    /// </summary>
-    /// <returns>Value indicating if the image can zoom in.</returns>
-    public bool CanZoomIn() => Zoom < MaxZoom;
-
-    /// <summary>
-    /// Zoom out the image.
-    /// </summary>
-    [RelayCommand(CanExecute = nameof(CanZoomOut))]
-    public void ZoomOut()
-    {
-        double newZoom = Math.Round(Zoom / ZoomDelta);
-        Zoom = (int)Math.Clamp(newZoom, MinZoom, MaxZoom);
-    }
-
-    /// <summary>
-    /// Gets a value indicating if the image can zoom out.
-    /// </summary>
-    /// <returns>Value indicating if the image can zoom out.</returns>
-    public bool CanZoomOut() => Zoom > MinZoom;
-
-    /// <summary>
     /// Save the current image to disk.
     /// </summary>
     /// <returns></returns>
@@ -143,15 +94,7 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     partial void OnImageChanged(IFullImage value)
     {
         SourceFormat = value;
-        Width = value.Width * Zoom / 100;
-        Height = value.Height * Zoom / 100;
         UpdateImage();
-    }
-
-    partial void OnZoomChanged(int value)
-    {
-        Width = Image.Width * Zoom / 100;
-        Height = Image.Height * Zoom / 100;
     }
 
     private void UpdateImage()

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -30,6 +30,12 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     [ObservableProperty]
     private Bitmap? bitmap;
 
+    [ObservableProperty]
+    private bool isIndexedImage;
+
+    [ObservableProperty]
+    private Bitmap? paletteImage;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
     /// </summary>
@@ -43,6 +49,12 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
 
             sourceFormat = null!;
             Image = new FullImage(256, 192) { Pixels = pixels };
+
+            var testPalette = new Palette(pixels[..256]);
+            using BinaryFormat palettePng = new Palette2Bitmap().Convert(testPalette);
+            palettePng.Stream.Position = 0;
+            PaletteImage = new Bitmap(palettePng.Stream);
+            IsIndexedImage = true;
         } else {
             image = null!;
             sourceFormat = null!;
@@ -74,6 +86,11 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
 
         Image = new Indexed2FullImage(palette).Convert(indexedImage);
         SourceFormat = indexedImage;
+
+        IsIndexedImage = true;
+        using BinaryFormat palettePng = new Palette2Bitmap().Convert(palette.Palettes[0]);
+        palettePng.Stream.Position = 0;
+        PaletteImage = new Bitmap(palettePng.Stream);
     }
 
     /// <summary>

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -12,6 +12,7 @@ using SceneGate.UI.Formats.Mvvm;
 using Texim.Colors;
 using Texim.Formats;
 using Texim.Images;
+using Texim.Palettes;
 using Yarhl.FileFormat;
 using Yarhl.IO;
 
@@ -58,6 +59,21 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
         : this()
     {
         Image = fullImage;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
+    /// </summary>
+    /// <param name="indexedImage">Image to display.</param>
+    /// <param name="palette">Palette for the indexed image.</param>
+    public ImageViewModel(IIndexedImage indexedImage, IPaletteCollection palette)
+        : this()
+    {
+        ArgumentNullException.ThrowIfNull(indexedImage);
+        ArgumentNullException.ThrowIfNull(palette);
+
+        Image = new Indexed2FullImage(palette).Convert(indexedImage);
+        SourceFormat = indexedImage;
     }
 
     /// <summary>

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -69,8 +69,8 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
             random.NextBytes(bytes);
             Rgb[] pixels = bytes.DecodeColorsAs<Rgb32>();
 
-            sourceFormat = null!;
             Image = new FullImage(256, 192) { Pixels = pixels };
+            sourceFormat = Image;
 
             var palette = new Palette(pixels[..256]);
             using BinaryFormat palettePng = new Palette2Bitmap().Convert(palette);

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -1,21 +1,25 @@
 ﻿namespace SceneGate.UI.Formats.Graphics;
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Texim.Colors;
 using Texim.Formats;
 using Texim.Images;
 using Yarhl.FileFormat;
 using Yarhl.IO;
 
+/// <summary>
+/// View model to display Yarhl images.
+/// </summary>
 public partial class ImageViewModel : ObservableObject, IFormatViewModel
 {
+    private const int MinZoom = 50;
+    private const int MaxZoom = 10_000;
+    private const double ZoomDelta = 1.1; // 10%
+
     [ObservableProperty]
     private IFullImage image;
 
@@ -31,17 +35,25 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     [ObservableProperty]
     private int height;
 
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ZoomInCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ZoomOutCommand))]
+    private int zoom;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageViewModel"/> class.
     /// </summary>
     public ImageViewModel()
     {
+        zoom = 100;
+
         if (Design.IsDesignMode) {
             byte[] bytes = new byte[256 * 192 * 4];
             var random = new Random(42);
             random.NextBytes(bytes);
             Rgb[] pixels = bytes.DecodeColorsAs<Rgb32>();
 
+            sourceFormat = null!;
             Image = new FullImage(256, 192) { Pixels = pixels };
         } else {
             image = null!;
@@ -59,12 +71,50 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
         Image = fullImage;
     }
 
+    /// <summary>
+    /// Zoom in the image.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanZoomIn))]
+    public void ZoomIn()
+    {
+        double newZoom = Math.Round(Zoom * ZoomDelta);
+        Zoom = (int)Math.Clamp(newZoom, MinZoom, MaxZoom);
+    }
+
+    /// <summary>
+    /// Gets a value indicating if the image can zoom in.
+    /// </summary>
+    /// <returns>Value indicating if the image can zoom in.</returns>
+    public bool CanZoomIn() => Zoom < MaxZoom;
+
+    /// <summary>
+    /// Zoom out the image.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanZoomOut))]
+    public void ZoomOut()
+    {
+        double newZoom = Math.Round(Zoom / ZoomDelta);
+        Zoom = (int)Math.Clamp(newZoom, MinZoom, MaxZoom);
+    }
+
+    /// <summary>
+    /// Gets a value indicating if the image can zoom out.
+    /// </summary>
+    /// <returns>Value indicating if the image can zoom out.</returns>
+    public bool CanZoomOut() => Zoom > MinZoom;
+
     partial void OnImageChanged(IFullImage value)
     {
         SourceFormat = value;
-        Width = value.Width;
-        Height = value.Height;
+        Width = value.Width * Zoom / 100;
+        Height = value.Height * Zoom / 100;
         UpdateImage();
+    }
+
+    partial void OnZoomChanged(int value)
+    {
+        Width = Image.Width * Zoom / 100;
+        Height = Image.Height * Zoom / 100;
     }
 
     private void UpdateImage()

--- a/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/ImageViewModel.cs
@@ -3,13 +3,11 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using SceneGate.UI.Formats.Mvvm;
-using Texim.Colors;
 using Texim.Compressions.Nitro;
 using Texim.Formats;
 using Texim.Images;
@@ -147,11 +145,16 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
         ArgumentNullException.ThrowIfNull(palettes);
 
         this.palettes = palettes;
+        maximumPaletteIndex = palettes.Palettes.Count - 1;
 
         isSinglePalette = true;
         canChangeToMultiPalette = false;
         isRawImage = true;
         rawImageOptions = new RawImageOptionsViewModel(binaryImage);
+
+        // Get the image created during the constructor, then update via event.
+        indexedImage = rawImageOptions.Image;
+        UpdateIndexedImage();
 
         rawImageOptions.PropertyChanged += (_, e) => {
             if (e.PropertyName == nameof(RawImageOptionsViewModel.Image)) {
@@ -228,6 +231,7 @@ public partial class ImageViewModel : ObservableObject, IFormatViewModel
     private void UpdateIndexedImage()
     {
         if (indexedImage is null || palettes is null) {
+            Bitmap = null;
             return;
         }
 

--- a/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
@@ -5,7 +5,7 @@
              xmlns:fluent="using:FluentAvalonia.UI.Controls"
              xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
              xmlns:local="using:SceneGate.UI.Formats.Graphics"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="600"
              x:Class="SceneGate.UI.Formats.Graphics.PaletteView"
              x:DataType="local:PaletteViewModel">
 
@@ -40,9 +40,7 @@
               CornerRadius="0 0 4 4"
               Background="{DynamicResource ControlFillColorInputActiveBrush}"
               Padding="5 10 5 5">
-        <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}"
-                          AllowFilter="False"
-                          AllowQuickFilter="False" />
+        <pgc:PropertyGrid SelectedObject="{Binding SourceFormat}" Classes="Simple ReadOnly" />
       </Border>
 
       <Border Grid.Row="3"
@@ -58,9 +56,7 @@
               CornerRadius="0 0 4 4"
               Background="{DynamicResource ControlFillColorInputActiveBrush}"
               Padding="5 10 5 5">
-        <pgc:PropertyGrid SelectedObject="{Binding SelectedPalette.Palette}"
-                          AllowFilter="False"
-                          AllowQuickFilter="False" />
+        <pgc:PropertyGrid SelectedObject="{Binding SelectedPalette.Palette}" Classes="Simple ReadOnly" />
       </Border>
     </Grid>
 

--- a/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml
@@ -5,7 +5,7 @@
              xmlns:fluent="using:FluentAvalonia.UI.Controls"
              xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
              xmlns:local="using:SceneGate.UI.Formats.Graphics"
-             mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="600"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="SceneGate.UI.Formats.Graphics.PaletteView"
              x:DataType="local:PaletteViewModel">
 
@@ -19,10 +19,11 @@
 
   <Grid ColumnDefinitions="*,Auto,Auto"
         RowDefinitions="*"
-        Margin="5">
+        Margin="5"
+        SizeChanged="MainGridSizeChanged">
 
     <Grid Grid.Row="0" Grid.Column="0"
-          IsVisible="{Binding IsModelPropertyVisible}"
+          Name="ModelPropertyGrid"
           RowDefinitions="Auto,Auto,1*,Auto,Auto,1*"
           HorizontalAlignment="Left"
           Margin="10 0">

--- a/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/PaletteView.axaml.cs
@@ -11,6 +11,8 @@ using Avalonia.Platform.Storage;
 /// </summary>
 public partial class PaletteView : UserControl
 {
+    private bool shouldDisplayProperties;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteView"/> class.
     /// </summary>
@@ -29,6 +31,7 @@ public partial class PaletteView : UserControl
         }
 
         var viewModel = (DataContext as PaletteViewModel)!;
+        shouldDisplayProperties = viewModel.IsModelPropertyVisible;
         viewModel.AskOutputFile.RegisterHandler(AskOutputFileAsync);
         viewModel.AskOutputFolder.RegisterHandler(AskOutputFolderAsync);
         viewModel.AskInputFile.RegisterHandler(AskInputFileAsync);
@@ -81,5 +84,14 @@ public partial class PaletteView : UserControl
             .OpenFilePickerAsync(options)
             .ConfigureAwait(false);
         return results.Count > 0 ? results[0] : null;
+    }
+
+    private void MainGridSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (e.NewSize.Width > 900) {
+            ModelPropertyGrid.IsVisible = shouldDisplayProperties;
+        } else {
+            ModelPropertyGrid.IsVisible = false;
+        }
     }
 }

--- a/src/SceneGate.UI.Formats/Graphics/PixelEncodingKind.cs
+++ b/src/SceneGate.UI.Formats/Graphics/PixelEncodingKind.cs
@@ -1,0 +1,74 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using Texim.Pixels;
+
+/// <summary>
+/// Kind of pixel encoding.
+/// </summary>
+public enum PixelEncodingKind
+{
+    /// <summary>
+    /// Indexed 4 bpp in little endian.
+    /// </summary>
+    Indexed4BppLittleEndian,
+
+    /// <summary>
+    /// Indexed 4 bpp in big endian.
+    /// </summary>
+    Indexed4BppBigEndian,
+
+    /// <summary>
+    /// Indexed 8 bpp.
+    /// </summary>
+    Indexed8Bpp,
+
+    /// <summary>
+    /// Indexed 8bpp: alpha 3-bits, index 5-bits
+    /// </summary>
+    IndexedA3I5,
+
+    /// <summary>
+    /// Indexed 8bpp: alpha 5-bits, index 3-bits.
+    /// </summary>
+    IndexedA5I3,
+}
+
+/// <summary>
+/// Extension methods for the <see cref="PixelEncodingKind"/> enum.
+/// </summary>
+public static class PixelEncodingExtensions
+{
+    /// <summary>
+    /// Get the pixel encoding of the indexed kinds.
+    /// </summary>
+    /// <param name="kind">Pixel encoding kind.</param>
+    /// <returns>The encoding implementation.</returns>
+    /// <exception cref="NotSupportedException">Unsupported format.</exception>
+    public static IIndexedPixelEncoding GetIndexedEncoding(this PixelEncodingKind kind) =>
+        kind switch {
+            PixelEncodingKind.Indexed4BppLittleEndian => Indexed4Bpp.Instance,
+            PixelEncodingKind.Indexed4BppBigEndian => Indexed4BppBigEndian.Instance,
+            PixelEncodingKind.Indexed8Bpp => Indexed8Bpp.Instance,
+            PixelEncodingKind.IndexedA3I5 => IndexedA3I5.Instance,
+            PixelEncodingKind.IndexedA5I3 => IndexedA5I3.Instance,
+            _ => throw new NotSupportedException("Unsupported format"),
+        };
+
+    /// <summary>
+    /// Gets the bits per pixel for the pixel encoding.
+    /// </summary>
+    /// <param name="kind">Pixel encoding kind.</param>
+    /// <returns>The bits per pixel for the encoding.</returns>
+    /// <exception cref="NotSupportedException">Unsupported format.</exception>
+    public static int GetBitsPerPixel(this PixelEncodingKind kind) =>
+        // TODO: move to texim
+        kind switch {
+            PixelEncodingKind.Indexed4BppLittleEndian => Indexed4Bpp.Instance.BitsPerPixel,
+            PixelEncodingKind.Indexed4BppBigEndian => Indexed4BppBigEndian.Instance.BitsPerPixel,
+            PixelEncodingKind.Indexed8Bpp => Indexed8Bpp.Instance.BitsPerPixel,
+            PixelEncodingKind.IndexedA3I5 => IndexedA3I5.Instance.BitsPerPixel,
+            PixelEncodingKind.IndexedA5I3 => IndexedA5I3.Instance.BitsPerPixel,
+            _ => throw new NotSupportedException("Unsupported format"),
+        };
+}

--- a/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
@@ -15,7 +15,7 @@
   
   <Grid ColumnDefinitions="Auto,Auto,Auto"
         RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*"
-        Margin="10 3">
+        Margin="5 3">
 
     <!-- Offset -->
     <Border Grid.Row="0" Grid.Column="0"

--- a/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
@@ -1,0 +1,205 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:fluent="using:FluentAvalonia.UI.Controls"
+             xmlns:controls="using:SceneGate.UI.Formats.Controls"
+             xmlns:local="using:SceneGate.UI.Formats.Graphics"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="500"
+             x:Class="SceneGate.UI.Formats.Graphics.RawImageOptionsView"
+             x:DataType="local:RawImageOptionsViewModel">
+
+  <Design.DataContext>
+    <local:RawImageOptionsViewModel />
+  </Design.DataContext>
+  
+  <Grid ColumnDefinitions="Auto,Auto,Auto"
+        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*"
+        Margin="10 3">
+
+    <!-- Offset -->
+    <Border Grid.Row="0" Grid.Column="0"
+            Height="32"
+            Margin="0 5"
+            Background="{DynamicResource TextControlBackgroundDisabled}"
+            BorderBrush="{DynamicResource TextControlBorderBrush}"
+            BorderThickness="1,1,0,1"
+            CornerRadius="4,0,0,4">
+      <TextBlock Text="Offset"
+                 Padding="5 0"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+    </Border>
+    <NumericUpDown Grid.Row="0" Grid.Column="1"
+                   Name="OffsetNumericBox"
+                   Margin="0 5"
+                   MinWidth="150"
+                   CornerRadius="0,4,4,0"
+                   FormatString="0"
+                   Value="{Binding Offset}"
+                   Minimum="0"
+                   Maximum="{Binding MaximumOffset}"
+                   FontFamily="{StaticResource CaskaydiaFont}"
+                   VerticalContentAlignment="Center">
+      <NumericUpDown.TextConverter>
+        <controls:HexadecimalValueConverter />
+      </NumericUpDown.TextConverter>
+    </NumericUpDown>
+    <CheckBox Grid.Row="0" Grid.Column="2"
+              Margin="10 5"
+              IsChecked="True"
+              Content="Hexadecimal"
+              IsCheckedChanged="OffsetHexCheckboxChecked"/>
+
+    <!-- Size -->
+    <Border Grid.Row="1" Grid.Column="0"
+            Height="32"
+            Margin="0 5"
+            Background="{DynamicResource TextControlBackgroundDisabled}"
+            BorderBrush="{DynamicResource TextControlBorderBrush}"
+            BorderThickness="1,1,0,1"
+            CornerRadius="4,0,0,4">
+      <TextBlock Text="Image size"
+                 Padding="5 0"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+    </Border>
+    <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+          ColumnDefinitions="*,Auto,*"
+          Margin="0 5">
+      <fluent:NumberBox Grid.Column="0"
+                        ToolTip.Tip="Image width"
+                        CornerRadius="0"
+                        SpinButtonPlacementMode="Hidden"
+                        HorizontalAlignment="Stretch"
+                        Value="{Binding Width}"
+                        Minimum="0"
+                        TextAlignment="Center"
+                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <Border Grid.Column="1"
+              Height="32"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="0">
+        <TextBlock Text="X"
+                   Padding="10 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <fluent:NumberBox Grid.Column="2"
+                        ToolTip.Tip="Image height"
+                        CornerRadius="0 4 4 0"
+                        SpinButtonPlacementMode="Hidden"
+                        HorizontalAlignment="Stretch"
+                        Value="{Binding Height}"
+                        Minimum="0"
+                        TextAlignment="Center"
+                        FontFamily="{StaticResource CaskaydiaFont}"/>
+    </Grid>
+
+    <!-- Bpp -->
+    <Border Grid.Row="2" Grid.Column="0"
+                Margin="0 5"
+                Height="32"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+      <TextBlock Text="Pixel format"
+                 Padding="5 0"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+    </Border>
+    <fluent:FAComboBox Grid.Row="2" Grid.Column="1"
+                       Margin="0 5"
+                       CornerRadius="0 4 4 0"
+                       SelectedIndex="0"
+                       IsEditable="False"
+                       HorizontalAlignment="Stretch">
+      <fluent:FAComboBoxItem Content="4bpp" />
+    </fluent:FAComboBox>
+
+    <!-- Swizzling -->
+    <Border Grid.Row="3" Grid.Column="0"
+                Margin="0 5"
+                Height="32"
+                Background="{DynamicResource TextControlBackgroundDisabled}"
+                BorderBrush="{DynamicResource TextControlBorderBrush}"
+                BorderThickness="1,1,0,1"
+                CornerRadius="4,0,0,4">
+      <TextBlock Text="Swizzling"
+                 Padding="5 0"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+    </Border>
+    <fluent:FAComboBox Grid.Row="3" Grid.Column="1"
+                       Margin="0 5"
+                       CornerRadius="0 4 4 0"
+                       SelectedIndex="0"
+                       IsEditable="False"
+                       HorizontalAlignment="Stretch">
+      <fluent:FAComboBoxItem Content="None" />
+      <fluent:FAComboBoxItem Content="Tiled" />
+    </fluent:FAComboBox>
+
+    <!-- Tile size -->
+    <Border Grid.Row="4" Grid.Column="0"
+            Height="32"
+            Margin="0 5"
+            Background="{DynamicResource TextControlBackgroundDisabled}"
+            BorderBrush="{DynamicResource TextControlBorderBrush}"
+            BorderThickness="1,1,0,1"
+            CornerRadius="4,0,0,4">
+      <TextBlock Text="Tile size"
+                 Padding="5 0"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+    </Border>
+    <Grid Grid.Row="4" Grid.Column="1"
+          ColumnDefinitions="*,Auto,*"
+          Margin="0 5"
+          IsEnabled="{Binding IsTiled}">
+      <fluent:NumberBox Grid.Column="0"
+                        ToolTip.Tip="Image width"
+                        CornerRadius="0"
+                        SpinButtonPlacementMode="Hidden"
+                        HorizontalAlignment="Stretch"
+                        Value="{Binding TileWidth}"
+                        Minimum="0"
+                        TextAlignment="Center"
+                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <Border Grid.Column="1"
+              Height="32"
+              Background="{DynamicResource TextControlBackgroundDisabled}"
+              BorderBrush="{DynamicResource TextControlBorderBrush}"
+              BorderThickness="1,1,0,1"
+              CornerRadius="0">
+        <TextBlock Text="X"
+                   Padding="10 0"
+                   FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+      </Border>
+      <fluent:NumberBox Grid.Column="2"
+                        ToolTip.Tip="Image height"
+                        CornerRadius="0 4 4 0"
+                        SpinButtonPlacementMode="Hidden"
+                        HorizontalAlignment="Stretch"
+                        Value="{Binding TileHeight}"
+                        Minimum="0"
+                        TextAlignment="Center"
+                        FontFamily="{StaticResource CaskaydiaFont}"/>
+    </Grid>
+
+    <TextBlock Grid.Row="5"
+               Text="Image bytes:"
+               FontWeight="SemiBold"
+               Margin="5 5 0 0" />
+    <TextBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3"
+             Margin="0 5 0 7"
+             Text="{Binding HexContent}"
+             IsReadOnly="True"
+             FontSize="13"
+             FontFamily="{StaticResource CaskaydiaFont}" />
+  </Grid>
+</UserControl>

--- a/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
+++ b/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml
@@ -10,7 +10,7 @@
              x:DataType="local:RawImageOptionsViewModel">
 
   <Design.DataContext>
-    <local:RawImageOptionsViewModel />
+    <local:DesignRawImageOptionsViewModel />
   </Design.DataContext>
   
   <Grid ColumnDefinitions="Auto,Auto,Auto"
@@ -67,15 +67,16 @@
     <Grid Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
           ColumnDefinitions="*,Auto,*"
           Margin="0 5">
-      <fluent:NumberBox Grid.Column="0"
-                        ToolTip.Tip="Image width"
-                        CornerRadius="0"
-                        SpinButtonPlacementMode="Hidden"
-                        HorizontalAlignment="Stretch"
-                        Value="{Binding Width}"
-                        Minimum="0"
-                        TextAlignment="Center"
-                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <NumericUpDown Grid.Column="0"
+                     ToolTip.Tip="Image width"
+                     CornerRadius="0"
+                     HorizontalAlignment="Stretch"
+                     ShowButtonSpinner="False"
+                     Value="{Binding Width}"
+                     FormatString="0"
+                     Minimum="1"
+                     TextAlignment="Center"
+                     FontFamily="{StaticResource CaskaydiaFont}"/>
       <Border Grid.Column="1"
               Height="32"
               Background="{DynamicResource TextControlBackgroundDisabled}"
@@ -87,15 +88,16 @@
                    FontWeight="SemiBold"
                    VerticalAlignment="Center" />
       </Border>
-      <fluent:NumberBox Grid.Column="2"
-                        ToolTip.Tip="Image height"
-                        CornerRadius="0 4 4 0"
-                        SpinButtonPlacementMode="Hidden"
-                        HorizontalAlignment="Stretch"
-                        Value="{Binding Height}"
-                        Minimum="0"
-                        TextAlignment="Center"
-                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <NumericUpDown Grid.Column="2"
+                     ToolTip.Tip="Image height"
+                     CornerRadius="0 4 4 0"
+                     ShowButtonSpinner="False"
+                     HorizontalAlignment="Stretch"
+                     Value="{Binding Height}"
+                     FormatString="0"
+                     Minimum="1"
+                     TextAlignment="Center"
+                     FontFamily="{StaticResource CaskaydiaFont}"/>
     </Grid>
 
     <!-- Bpp -->
@@ -116,9 +118,9 @@
                        CornerRadius="0 4 4 0"
                        SelectedIndex="0"
                        IsEditable="False"
-                       HorizontalAlignment="Stretch">
-      <fluent:FAComboBoxItem Content="4bpp" />
-    </fluent:FAComboBox>
+                       HorizontalAlignment="Stretch"
+                       ItemsSource="{Binding AllPixelEncodings}"
+                       SelectedItem="{Binding PixelEncoding}" />
 
     <!-- Swizzling -->
     <Border Grid.Row="3" Grid.Column="0"
@@ -138,10 +140,9 @@
                        CornerRadius="0 4 4 0"
                        SelectedIndex="0"
                        IsEditable="False"
-                       HorizontalAlignment="Stretch">
-      <fluent:FAComboBoxItem Content="None" />
-      <fluent:FAComboBoxItem Content="Tiled" />
-    </fluent:FAComboBox>
+                       HorizontalAlignment="Stretch"
+                       ItemsSource="{Binding AllSwizzlingKinds}"
+                       SelectedItem="{Binding SwizzlingKind}" />
 
     <!-- Tile size -->
     <Border Grid.Row="4" Grid.Column="0"
@@ -160,15 +161,16 @@
           ColumnDefinitions="*,Auto,*"
           Margin="0 5"
           IsEnabled="{Binding IsTiled}">
-      <fluent:NumberBox Grid.Column="0"
-                        ToolTip.Tip="Image width"
-                        CornerRadius="0"
-                        SpinButtonPlacementMode="Hidden"
-                        HorizontalAlignment="Stretch"
-                        Value="{Binding TileWidth}"
-                        Minimum="0"
-                        TextAlignment="Center"
-                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <NumericUpDown Grid.Column="0"
+                     ToolTip.Tip="Image width"
+                     CornerRadius="0"
+                     ShowButtonSpinner="False"
+                     HorizontalAlignment="Stretch"
+                     Value="{Binding TileWidth}"
+                     FormatString="0"
+                     Minimum="1"
+                     TextAlignment="Center"
+                     FontFamily="{StaticResource CaskaydiaFont}"/>
       <Border Grid.Column="1"
               Height="32"
               Background="{DynamicResource TextControlBackgroundDisabled}"
@@ -180,15 +182,16 @@
                    FontWeight="SemiBold"
                    VerticalAlignment="Center" />
       </Border>
-      <fluent:NumberBox Grid.Column="2"
-                        ToolTip.Tip="Image height"
-                        CornerRadius="0 4 4 0"
-                        SpinButtonPlacementMode="Hidden"
-                        HorizontalAlignment="Stretch"
-                        Value="{Binding TileHeight}"
-                        Minimum="0"
-                        TextAlignment="Center"
-                        FontFamily="{StaticResource CaskaydiaFont}"/>
+      <NumericUpDown Grid.Column="2"
+                     ToolTip.Tip="Image height"
+                     CornerRadius="0 4 4 0"
+                     ShowButtonSpinner="False"
+                     HorizontalAlignment="Stretch"
+                     Value="{Binding TileHeight}"
+                     FormatString="0"
+                     Minimum="1"
+                     TextAlignment="Center"
+                     FontFamily="{StaticResource CaskaydiaFont}"/>
     </Grid>
 
     <TextBlock Grid.Row="5"

--- a/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml.cs
+++ b/src/SceneGate.UI.Formats/Graphics/RawImageOptionsView.axaml.cs
@@ -1,0 +1,39 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System.Globalization;
+using Avalonia.Controls;
+using SceneGate.UI.Formats.Controls;
+
+/// <summary>
+/// User control to define the options of a raw image.
+/// </summary>
+public partial class RawImageOptionsView : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RawImageOptionsView"/> class.
+    /// </summary>
+    public RawImageOptionsView()
+    {
+        InitializeComponent();
+    }
+
+    private void OffsetHexCheckboxChecked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var checkbox = sender as CheckBox;
+        OffsetNumericBox.TextConverter = (checkbox?.IsChecked ?? false)
+            ? new HexadecimalValueConverter()
+            : null;
+        RefreshNumericBox(OffsetNumericBox);
+    }
+
+    private void RefreshNumericBox(NumericUpDown box)
+    {
+        // Due to a bug in Avalonia, it doesn't refresh the text when the converter changes
+        // We do it manually
+        if (box.TextConverter is null) {
+            box.Text = box.Value?.ToString(box.FormatString, box.NumberFormat);
+        } else {
+            box.Text = box.TextConverter.ConvertBack(box.Value, typeof(string), null, CultureInfo.CurrentCulture)?.ToString();
+        }
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/RawImageOptionsViewModel.cs
+++ b/src/SceneGate.UI.Formats/Graphics/RawImageOptionsViewModel.cs
@@ -1,0 +1,139 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Text;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Texim.Formats;
+using Texim.Images;
+using Texim.Pixels;
+using Yarhl.IO;
+
+/// <summary>
+/// View model to set and display the options of raw images.
+/// </summary>
+public partial class RawImageOptionsViewModel : ObservableObject
+{
+    private readonly IBinary binaryFormat;
+    private readonly StringBuilder hexBuilder;
+
+    [ObservableProperty]
+    private IndexedImage? image;
+
+    [ObservableProperty]
+    private long offset;
+
+    [ObservableProperty]
+    private long maximumOffset;
+
+    [ObservableProperty]
+    private int width;
+
+    [ObservableProperty]
+    private int height;
+
+    [ObservableProperty]
+    private int pixelEncoding;
+
+    [ObservableProperty]
+    private int swizzlingKind;
+
+    [ObservableProperty]
+    private bool isTiled;
+
+    [ObservableProperty]
+    private int tileWidth;
+
+    [ObservableProperty]
+    private int tileHeight;
+
+    [ObservableProperty]
+    private string hexContent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RawImageOptionsViewModel"/> class.
+    /// </summary>
+    public RawImageOptionsViewModel()
+    {
+        Offset = 0;
+        TileWidth = 8;
+        TileHeight = 8;
+        hexContent = string.Empty;
+        hexBuilder = new StringBuilder();
+
+        if (Design.IsDesignMode) {
+            Width = 256;
+            Height = 192;
+
+            var random = new Random(42);
+            byte[] colorBytes = new byte[Width * Height];
+            random.NextBytes(colorBytes);
+            DataStream stream = DataStreamFactory.FromArray(colorBytes);
+            binaryFormat = new BinaryFormat(stream);
+
+            ReadImage();
+        } else {
+            binaryFormat = null!;
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RawImageOptionsViewModel"/> class.
+    /// </summary>
+    /// <param name="binaryFormat">The binary data to see as image.</param>
+    public RawImageOptionsViewModel(IBinary binaryFormat)
+        : this()
+    {
+        ArgumentNullException.ThrowIfNull(binaryFormat);
+
+        // TODO: guess sizes
+        this.binaryFormat = binaryFormat;
+        MaximumOffset = binaryFormat.Stream.Length;
+
+        ReadImage();
+    }
+
+    private int Size => (int)Math.Ceiling(Width * Height * Indexed4Bpp.Instance.BitsPerPixel / 8.0);
+
+    private void ReadImage()
+    {
+        ReadHexContent();
+        ConvertImage();
+    }
+
+    private void ConvertImage()
+    {
+        var options = new RawIndexedImageParams {
+            Width = Width,
+            Height = Height,
+            Offset = Offset,
+            PixelEncoding = Indexed8Bpp.Instance,
+            Size = Size,
+            Swizzling = new TileSwizzling<IndexedPixel>(new(TileWidth, TileHeight), Width),
+        };
+        Image = new RawBinary2IndexedImage(options).Convert(binaryFormat);
+    }
+
+    private void ReadHexContent()
+    {
+        binaryFormat.Stream.Position = Offset;
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(Size);
+        int read = binaryFormat.Stream.Read(buffer, 0, Size);
+
+        hexBuilder.Clear();
+        for (int i = 0; i < read; i++) {
+            if (i + 1 == read) {
+                hexBuilder.AppendFormat("{0:X2}", buffer[i]);
+            } else if (i != 0 && ((i + 1) % 16 == 0)) {
+                hexBuilder.AppendFormat("{0:X2}\n", buffer[i]);
+            } else {
+                hexBuilder.AppendFormat("{0:X2} ", buffer[i]);
+            }
+        }
+
+        HexContent = hexBuilder.ToString();
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+}

--- a/src/SceneGate.UI.Formats/Graphics/SwizzlingKind.cs
+++ b/src/SceneGate.UI.Formats/Graphics/SwizzlingKind.cs
@@ -1,0 +1,17 @@
+﻿namespace SceneGate.UI.Formats.Graphics;
+
+/// <summary>
+/// Kind of pixel swizzling for images.
+/// </summary>
+public enum SwizzlingKind
+{
+    /// <summary>
+    /// No swizzling (lineal).
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Tiles of a given size read by row.
+    /// </summary>
+    TiledHorizontal,
+}

--- a/src/SceneGate.UI.Formats/IFormatViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/IFormatViewModelBuilder.cs
@@ -1,5 +1,7 @@
 ﻿namespace SceneGate.UI.Formats;
 
+using System;
+using System.Collections.Generic;
 using Yarhl.FileFormat;
 
 /// <summary>
@@ -12,12 +14,12 @@ public interface IFormatViewModelBuilder
     /// </summary>
     /// <param name="format">The format to check.</param>
     /// <returns>Value indicating if the view model supports the format.</returns>
-    bool CanShow(IFormat format);
+    bool CanShow(IFormat format, IReadOnlyCollection<Type> formatsCache);
 
     /// <summary>
     /// Creates a new view model for the given format.
     /// </summary>
     /// <param name="format">The format to get its view model.</param>
     /// <returns>The new view model.</returns>
-    IFormatViewModel Build(IFormat format);
+    IFormatViewModel Build(IFormat format, IReadOnlyDictionary<Type, IFormat> formatsCache);
 }

--- a/src/SceneGate.UI.Formats/IFormatViewModelBuilder.cs
+++ b/src/SceneGate.UI.Formats/IFormatViewModelBuilder.cs
@@ -13,6 +13,7 @@ public interface IFormatViewModelBuilder
     /// Returns a value indicating whether the view model support the given format.
     /// </summary>
     /// <param name="format">The format to check.</param>
+    /// <param name="formatsCache">Cache of recent formats opened and available.</param>
     /// <returns>Value indicating if the view model supports the format.</returns>
     bool CanShow(IFormat format, IReadOnlyCollection<Type> formatsCache);
 
@@ -20,6 +21,7 @@ public interface IFormatViewModelBuilder
     /// Creates a new view model for the given format.
     /// </summary>
     /// <param name="format">The format to get its view model.</param>
+    /// <param name="formatsCache">Cache of recent formats opened and available.</param>
     /// <returns>The new view model.</returns>
     IFormatViewModel Build(IFormat format, IReadOnlyDictionary<Type, IFormat> formatsCache);
 }

--- a/src/SceneGate.UI.Formats/SceneGate.UI.Formats.csproj
+++ b/src/SceneGate.UI.Formats/SceneGate.UI.Formats.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.AvaloniaEdit" />
+    <PackageReference Include="Avalonia.Controls.PanAndZoom" />
     <PackageReference Include="Avalonia.Xaml.Interactions" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
     <PackageReference Include="bodong.Avalonia.PropertyGrid" />

--- a/src/SceneGate.UI.Formats/SceneGate.UI.Formats.csproj
+++ b/src/SceneGate.UI.Formats/SceneGate.UI.Formats.csproj
@@ -5,6 +5,7 @@
     <IsPackable>true</IsPackable>
 
     <TargetFramework>net8.0</TargetFramework>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 
     <Nullable>enable</Nullable>
 

--- a/src/SceneGate.UI.Formats/Texts/PoView.axaml
+++ b/src/SceneGate.UI.Formats/Texts/PoView.axaml
@@ -18,7 +18,6 @@
     <DataGrid Grid.Column="0"
               ItemsSource="{Binding Entries}"
               SelectedItem="{Binding SelectedEntry}"
-              x:DataType="local:PoEntryViewModel"
               CanUserReorderColumns="False"
               CanUserSortColumns="False"
               CanUserResizeColumns="True"

--- a/src/SceneGate.UI/ControlsData/TreeGridNode.cs
+++ b/src/SceneGate.UI/ControlsData/TreeGridNode.cs
@@ -3,10 +3,10 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Texim.Compressions.Nitro;
 using Texim.Images;
 using Texim.Palettes;
 using Yarhl.FileSystem;
@@ -207,6 +207,7 @@ public partial class TreeGridNode : ObservableObject
 
             IFullImage => NodeFormatKind.Image,
             IIndexedImage => NodeFormatKind.Image,
+            IScreenMap => NodeFormatKind.Image, // it should go in Ekona somehow?
 
             _ => NodeFormatKind.Unknown,
         };

--- a/src/SceneGate.UI/ControlsData/TreeGridNode.cs
+++ b/src/SceneGate.UI/ControlsData/TreeGridNode.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Texim.Images;
 using Texim.Palettes;
 using Yarhl.FileSystem;
 using Yarhl.IO;
@@ -203,6 +204,9 @@ public partial class TreeGridNode : ObservableObject
 
             IPalette => NodeFormatKind.Palette,
             IPaletteCollection => NodeFormatKind.Palette,
+
+            IFullImage => NodeFormatKind.Image,
+            IIndexedImage => NodeFormatKind.Image,
 
             _ => NodeFormatKind.Unknown,
         };

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
@@ -107,7 +107,8 @@
                                            Command="{ReflectionBinding $parent[TreeView].DataContext.OpenAsRawPaletteCommand}"/>
                     <fluent:MenuFlyoutItem Text="Raw image"
                                            IconSource="Image"
-                                           IsEnabled="False" />
+                                           HotKey="I"
+                                           Command="{ReflectionBinding $parent[TreeView].DataContext.OpenAsRawImageCommand}"/>
                   </fluent:MenuFlyoutSubItem>
                 </fluent:FAMenuFlyout>
               </Grid.ContextFlyout>

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
@@ -102,6 +102,8 @@ public partial class AnalyzeView : UserControl
             viewModel.OpenWithHexViewerCommand.Execute(null);
         } else if (e.Key == Key.P && viewModel.OpenAsRawPaletteCommand.CanExecute(null)) {
             viewModel.OpenAsRawPaletteCommand.Execute(null);
+        } else if (e.Key == Key.I && viewModel.OpenAsRawImageCommand.CanExecute(null)) {
+            viewModel.OpenAsRawImageCommand.Execute(null);
         }
     }
 

--- a/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
@@ -191,6 +191,11 @@ public partial class AnalyzeViewModel : ViewModelBase
         }
 
         FormatViewTabs.Remove(tab);
+
+        // It seems there is a bug when closing not-the-last-tab, force a refresh
+        NodeFormatTab? newTab = SelectedTab;
+        SelectedTab = null;
+        SelectedTab = newTab;
     }
 
     [RelayCommand(CanExecute = nameof(CanConvertNode))]

--- a/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
@@ -15,6 +15,7 @@ using SceneGate.UI.Formats;
 using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Mvvm;
+using Texim.Palettes;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
 using Yarhl.IO;
@@ -329,6 +330,24 @@ public partial class AnalyzeViewModel : ViewModelBase
     }
 
     private bool CanOpenAsRawPalette() => SelectedNode?.Node.Format is IBinary;
+
+    [RelayCommand(CanExecute = nameof(CanOpenAsRawImage))]
+    private void OpenAsRawImage()
+    {
+        if (SelectedNode?.Node.Format is not IBinary format) {
+            return;
+        }
+
+        if (formatsCache[typeof(IPaletteCollection)] is not IPaletteCollection palettes) {
+            return;
+        }
+
+        var viewModel = new ImageViewModel(format, palettes);
+        OpenNodeViewWith(viewModel);
+    }
+
+    private bool CanOpenAsRawImage() =>
+        SelectedNode?.Node.Format is IBinary && formatsCache.ContainsKey(typeof(IPaletteCollection));
 
     partial void OnNodeNameFilterChanged(string? value)
     {

--- a/src/SceneGate.UI/Styling/ControlsStyle.axaml
+++ b/src/SceneGate.UI/Styling/ControlsStyle.axaml
@@ -2,18 +2,46 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="using:FluentAvalonia.UI.Controls"
         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
+        xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
         xmlns:cd="using:SceneGate.UI.ControlsData">
 
   <Design.PreviewWith>
     <Border Padding="30" MinWidth="350" Height="500">
-      <ColorView
-        Classes="ReadOnly NoHeader"
-        IsAlphaVisible="False"
-        IsColorSpectrumVisible="False"
-        IsColorPaletteVisible="False"/>
+      <ScrollViewer>
+        <pgc:PropertyGrid Classes="ReadOnly Simple">
+          <pgc:PropertyGrid.SelectedObject>
+            <TextBox/>
+          </pgc:PropertyGrid.SelectedObject>
+        </pgc:PropertyGrid>
+      </ScrollViewer>
     </Border>
   </Design.PreviewWith>
 
+  <!-- Simple and readonly styles for propertygrid -->
+  <Style Selector="pgc|PropertyGrid.Simple">
+    <Setter Property="AllowFilter" Value="False" />
+    <Setter Property="AllowQuickFilter" Value="False" />
+    <Setter Property="ShowTitle" Value="False" />
+    <Setter Property="ShowStyle" Value="Alphabetic" />
+  </Style>
+  <Style Selector="pgc|PropertyGrid.ReadOnly">
+    <Style Selector="^ TextBox">
+      <Setter Property="IsReadOnly" Value="True" />
+    </Style>
+    <Style Selector="^ NumericUpDown">
+      <Setter Property="IsReadOnly" Value="True" />
+    </Style>
+    <Style Selector="^ CheckBox">
+      <Setter Property="IsEnabled" Value="False" />
+    </Style>
+    <Style Selector="^ ComboBox">
+      <Setter Property="IsEnabled" Value="False" />
+    </Style>
+    <Style Selector="^ pgc|CheckedListEdit">
+      <Setter Property="IsEnabled" Value="False" />
+    </Style>
+  </Style>
+  
   <!-- SelectableTextBlock doesn't have a SelectionForegroundBrush so it doesn't look right on Light themes -->
   <Style Selector="SelectableTextBlock">
     <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
@@ -43,6 +71,7 @@
     <Setter Property="IsVisible" Value="False" />
   </Style>
 
+  <!-- Compact style for tree views -->
   <Style Selector="TreeView.Compact TreeViewItem">
     <Setter Property="MinHeight" Value="22" />
   </Style>


### PR DESCRIPTION
New format view to visualize images: `IFullImage`, `IIndexedImage` and after compression with `IScreenMap`. It also allows to see raw images.

It allows to see the object property, zoom in and out (and reset) and save as PNG to disk. The first color can be seen as transparent and for indexed images we can select the palette.

Part of #13

## Quality check list

- [x] Related code has been tested automatically or manually
- [ ] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Display `IFullImage`
- Display `IIndexedImage`
- Display and decompress for `IScreenMap`
- Open `IBinary` as raw image with different parameters: offset, length,...
- See first color as transparent
- choose palette number

## Follow-up work

None

## Example

- RGB images: 
![image](https://github.com/SceneGate/SceneGate/assets/3107481/96f97c12-e9b3-4f93-8ca7-b628291ea002)
- Indexed images: 
![image](https://github.com/SceneGate/SceneGate/assets/3107481/da47248e-68b2-4dcc-9c5b-370f53e8113a)
- Map compression images (NSCR): 
![image](https://github.com/SceneGate/SceneGate/assets/3107481/e1a48a09-ebb0-46d1-9c7e-b735cf6ed78e)
- Raw image viewer: 
![image](https://github.com/SceneGate/SceneGate/assets/3107481/4fcd02b0-4d4c-4f0f-8e92-000c497230b9)