### PR TITLE
:sparkles: Implement converter decompiler view

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="SceneGate.Lemon" Version="0.1.0-preview.102" />
     <PackageVersion Include="SceneGate.Ekona" Version="0.1.0-preview.111" />
     <PackageVersion Include="Texim.Games" Version="0.1.0-preview.208" />
-    <PackageVersion Include="SceneGate.Games.PokemonConquest" Version="3.0.0-preview.125" />
+    <PackageVersion Include="SceneGate.Games.PokemonConquest" Version="3.0.0-preview.127" />
     <PackageVersion Include="SceneGate.Games.ProfessorLayton" Version="0.1.1-preview.8" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="bodong.PropertyModels" Version="11.0.5.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageVersion Include="FluentAvaloniaUI" Version="2.0.4" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />
     <PackageVersion Include="nunit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/src/SceneGate.UI/ControlsData/NodeFormatTab.cs
+++ b/src/SceneGate.UI/ControlsData/NodeFormatTab.cs
@@ -11,7 +11,7 @@ public partial class NodeFormatTab : ObservableObject
     [ObservableProperty]
     private NodeFormatKind kind;
 
-    public NodeFormatTab(Node node, NodeFormatKind kind, IFormatViewModel content)
+    public NodeFormatTab(Node node, NodeFormatKind kind, object content)
     {
         Node = node;
         Name = node.Name;
@@ -21,5 +21,5 @@ public partial class NodeFormatTab : ObservableObject
 
     public Node Node { get; }
 
-    public IFormatViewModel Content { get; }
+    public object Content { get; }
 }

--- a/src/SceneGate.UI/ControlsData/TreeGridConverter.cs
+++ b/src/SceneGate.UI/ControlsData/TreeGridConverter.cs
@@ -84,7 +84,7 @@ public sealed partial class TreeGridConverter : ObservableObject
             converterName = converter.Type.Name;
         }
 
-        if (!current.Children.Any(x => x.Converter?.DestinationType == converter.DestinationType)) {
+        if (!current.Children.Any(x => x.Converter?.Type == converter.Type)) {
             current.Children.Add(new TreeGridConverter(converter, converterName));
         }
     }

--- a/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml
+++ b/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml
@@ -1,0 +1,84 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:fluent="using:FluentAvalonia.UI.Controls"
+             xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="using:SceneGate.UI.Formats.CodeEditor"
+             xmlns:local="using:SceneGate.UI.Pages.Analyze"
+             mc:Ignorable="d" d:DesignWidth="1050" d:DesignHeight="800"
+             x:Class="SceneGate.UI.Pages.Analyze.DecompileView"
+             x:DataType="local:DecompileViewModel">
+
+  <Design.DataContext>
+    <local:DesignDecompileViewModel />
+  </Design.DataContext>
+  
+  <Grid RowDefinitions="Auto,*"
+        Margin="10">
+    <Grid ColumnDefinitions="Auto,*"
+          RowDefinitions="Auto,Auto,Auto,Auto">
+      <TextBlock Grid.Row="0" Grid.Column="0"
+                 Margin="5 0 0 5"
+                 Text="Type:"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center" />
+      <TextBox Grid.Row="0" Grid.Column="1"
+               Margin="5 0 0 5"
+               IsReadOnly="True"
+               Text="{Binding TypeName}"
+               FontFamily="{StaticResource CaskaydiaFont}"/>
+
+      <TextBlock Grid.Row="1" Grid.Column="0"
+           Margin="5 0 0 5"
+           Text="Assembly:"
+           FontWeight="SemiBold"
+           VerticalAlignment="Center" />
+      <TextBox Grid.Row="1" Grid.Column="1"
+               Margin="5 0 0 5"
+               IsReadOnly="True"
+               Text="{Binding AssemblyName}"
+               FontFamily="{StaticResource CaskaydiaFont}"/>
+
+      <TextBlock Grid.Row="2" Grid.Column="0"
+           Margin="5 0 0 5"
+           Text="Location:"
+           FontWeight="SemiBold"
+           VerticalAlignment="Center" />
+      <TextBox Grid.Row="2" Grid.Column="1"
+               Margin="5 0 0 5"
+               IsReadOnly="True"
+               Text="{Binding AssemblyLocation}"
+               ToolTip.Tip="{Binding AssemblyLocation}"
+               TextWrapping="Wrap"
+               FontFamily="{StaticResource CaskaydiaFont}"/>
+
+      <TextBlock Grid.Row="3" Grid.Column="0"
+                 Margin="5 0 0 0"
+                 Text="Repository:"
+                 FontWeight="SemiBold"
+                 VerticalAlignment="Center"/>
+      <fluent:HyperlinkButton Grid.Row="3" Grid.Column="1"
+                              Margin="0"
+                              Content="{Binding RepositoryName}"
+                              NavigateUri="{Binding RepositoryUrl}"
+                              ToolTip.Tip="{Binding RepositoryUrl}"
+                              VerticalAlignment="Center"/>
+    </Grid>
+
+    <AvaloniaEdit:TextEditor Grid.Row="1"
+                             Margin="0 15 0 0"
+                             ShowLineNumbers="True"
+                             SyntaxHighlighting="C#"
+                             IsReadOnly="True"
+                             BorderThickness="1"
+                             BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                             FontFamily="{StaticResource CaskaydiaFont}">
+      <i:Interaction.Behaviors>
+        <behaviors:DocumentTextBindingBehavior Text="{Binding DecompiledType}"/>
+      </i:Interaction.Behaviors>
+    </AvaloniaEdit:TextEditor>
+  </Grid>
+  
+</UserControl>

--- a/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml
+++ b/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml
@@ -17,7 +17,7 @@
   
   <Grid RowDefinitions="Auto,*"
         Margin="10">
-    <Grid ColumnDefinitions="Auto,*"
+    <Grid ColumnDefinitions="Auto,1.5*,Auto,1*"
           RowDefinitions="Auto,Auto,Auto,Auto">
       <TextBlock Grid.Row="0" Grid.Column="0"
                  Margin="5 0 0 5"
@@ -30,15 +30,37 @@
                Text="{Binding TypeName}"
                FontFamily="{StaticResource CaskaydiaFont}"/>
 
-      <TextBlock Grid.Row="1" Grid.Column="0"
+      <TextBlock Grid.Row="0" Grid.Column="2"
            Margin="5 0 0 5"
            Text="Assembly:"
+           FontWeight="SemiBold"
+           VerticalAlignment="Center" />
+      <TextBox Grid.Row="0" Grid.Column="3"
+               Margin="5 0 0 5"
+               IsReadOnly="True"
+               Text="{Binding AssemblyName}"
+               FontFamily="{StaticResource CaskaydiaFont}"/>
+
+      <TextBlock Grid.Row="1" Grid.Column="0"
+           Margin="5 0 0 5"
+           Text="Copyright:"
            FontWeight="SemiBold"
            VerticalAlignment="Center" />
       <TextBox Grid.Row="1" Grid.Column="1"
                Margin="5 0 0 5"
                IsReadOnly="True"
-               Text="{Binding AssemblyName}"
+               Text="{Binding AssemblyCopyright}"
+               FontFamily="{StaticResource CaskaydiaFont}"/>
+
+      <TextBlock Grid.Row="1" Grid.Column="2"
+           Margin="5 0 0 5"
+           Text="Version:"
+           FontWeight="SemiBold"
+           VerticalAlignment="Center" />
+      <TextBox Grid.Row="1" Grid.Column="3"
+               Margin="5 0 0 5"
+               IsReadOnly="True"
+               Text="{Binding AssemblyVersion}"
                FontFamily="{StaticResource CaskaydiaFont}"/>
 
       <TextBlock Grid.Row="2" Grid.Column="0"
@@ -46,7 +68,7 @@
            Text="Location:"
            FontWeight="SemiBold"
            VerticalAlignment="Center" />
-      <TextBox Grid.Row="2" Grid.Column="1"
+      <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3"
                Margin="5 0 0 5"
                IsReadOnly="True"
                Text="{Binding AssemblyLocation}"
@@ -59,11 +81,14 @@
                  Text="Repository:"
                  FontWeight="SemiBold"
                  VerticalAlignment="Center"/>
-      <fluent:HyperlinkButton Grid.Row="3" Grid.Column="1"
-                              Margin="0"
-                              Content="{Binding RepositoryName}"
+      <TextBox Grid.Row="3" Grid.Column="1"
+               Margin="5 0 0 0"
+               IsReadOnly="True"
+               Text="{Binding RepositoryUrl}"
+               FontFamily="{StaticResource CaskaydiaFont}" />
+      <fluent:HyperlinkButton Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
+                              Content="Go to website"
                               NavigateUri="{Binding RepositoryUrl}"
-                              ToolTip.Tip="{Binding RepositoryUrl}"
                               VerticalAlignment="Center"/>
     </Grid>
 

--- a/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml.cs
+++ b/src/SceneGate.UI/Pages/Analyze/DecompileView.axaml.cs
@@ -1,0 +1,11 @@
+﻿namespace SceneGate.UI.Pages.Analyze;
+
+using Avalonia.Controls;
+
+public partial class DecompileView : UserControl
+{
+    public DecompileView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SceneGate.UI/Pages/Analyze/DecompileViewModel.cs
+++ b/src/SceneGate.UI/Pages/Analyze/DecompileViewModel.cs
@@ -1,0 +1,73 @@
+﻿namespace SceneGate.UI.Pages.Analyze;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.TypeSystem;
+
+public partial class DecompileViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string repositoryName;
+
+    [ObservableProperty]
+    private string repositoryUrl;
+
+    [ObservableProperty]
+    private string decompiledType;
+
+    [ObservableProperty]
+    private string typeName;
+
+    [ObservableProperty]
+    private string assemblyName;
+
+    [ObservableProperty]
+    private string assemblyLocation;
+
+    public DecompileViewModel(Type targetType)
+    {
+        ArgumentNullException.ThrowIfNull(targetType);
+
+        repositoryName = "Cannot determine";
+        repositoryUrl = string.Empty;
+        decompiledType = string.Empty;
+
+        TypeName = targetType.FullName ?? "Unknown";
+        AssemblyName = targetType.Assembly.FullName ?? "Unknown";
+        AssemblyLocation = targetType.Assembly.Location;
+
+        GetRepositoryInfo(targetType);
+        DecompileType(targetType);
+    }
+
+    private void GetRepositoryInfo(Type type)
+    {
+        Assembly assembly = type.Assembly;
+
+        var assemblyMetadata = assembly.GetCustomAttributes<AssemblyMetadataAttribute>();
+        var repositoryInfo = assemblyMetadata.FirstOrDefault(x => x.Key == "RepositoryUrl");
+        if (repositoryInfo is not null) {
+            RepositoryUrl = repositoryInfo.Value ?? string.Empty;
+            RepositoryName = new Uri(RepositoryUrl).AbsolutePath;
+            if (RepositoryName.Length > 0) {
+                RepositoryName = RepositoryName[1..]; // remove leading '/'
+            }
+        }
+    }
+
+    private void DecompileType(Type type)
+    {
+        string assemblyPath = type.Assembly.Location;
+        var decompiler = new CSharpDecompiler(assemblyPath, new DecompilerSettings());
+        try {
+            var typeName = new FullTypeName(type.FullName);
+            DecompiledType = decompiler.DecompileTypeAsString(typeName);
+        } catch (Exception ex) {
+            DecompiledType = ex.ToString();
+        }
+    }
+}

--- a/src/SceneGate.UI/Pages/Analyze/DesignDecompileViewModel.cs
+++ b/src/SceneGate.UI/Pages/Analyze/DesignDecompileViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace SceneGate.UI.Pages.Analyze;
+
+using Yarhl.Media.Text;
+
+public class DesignDecompileViewModel : DecompileViewModel
+{
+    public DesignDecompileViewModel()
+        : base(typeof(Po2Binary))
+    {
+    }
+}

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml
@@ -162,6 +162,8 @@
                   <MenuFlyout>
                     <MenuItem Header="Copy type name"
                               Command="{ReflectionBinding $parent[TreeView].DataContext.CopyConverterTypeNameCommand}"/>
+                    <MenuItem Header="Decompile"
+                              Command="{ReflectionBinding $parent[TreeView].DataContext.OpenDecompiledConverterCommand}" />
                   </MenuFlyout>
                 </StackPanel.ContextFlyout>
               </StackPanel>

--- a/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeView.axaml.cs
@@ -69,7 +69,7 @@ public partial class AnalyzeView : UserControl
         errorConversionDialog.XamlRoot = VisualRoot as Visual;
         convertingDialog.XamlRoot = VisualRoot as Visual;
 
-        // As converter list doesn't change we can do it once
+        // TODO: no longer true. As converter list doesn't change we can do it once
         foreach (object? item in converterTreeView.Items) {
             Control? itemView = converterTreeView.ContainerFromItem(item!);
             if (itemView is TreeViewItem treeViewItem) {

--- a/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
@@ -403,7 +403,8 @@ public partial class AnalyzeViewModel : ViewModelBase
 
     private void FindNewConverterNodes()
     {
-        foreach (ConverterTypeInfo converter in ConverterLocator.Default.Converters) {
+        var converters = ConverterLocator.Default.Converters.ToList();
+        foreach (ConverterTypeInfo converter in converters) {
             TreeGridConverter.InsertConverterHierarchy(converter, ConverterNodes, groupByNamespace: false);
         }
     }

--- a/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
+++ b/src/SceneGate.UI/Pages/Main/AnalyzeViewModel.cs
@@ -15,6 +15,7 @@ using SceneGate.UI.Formats;
 using SceneGate.UI.Formats.Common;
 using SceneGate.UI.Formats.Graphics;
 using SceneGate.UI.Formats.Mvvm;
+using SceneGate.UI.Pages.Analyze;
 using Texim.Palettes;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
@@ -300,6 +301,27 @@ public partial class AnalyzeViewModel : ViewModelBase
 
     private bool CanCopyConverterTypeName() =>
         SelectedConverter is { Kind: TreeGridConverterKind.Converter };
+
+    [RelayCommand(CanExecute = nameof(CanOpenDecompiledConverter))]
+    private void OpenDecompiledConverter()
+    {
+        ConverterTypeInfo? converter = SelectedConverter?.Converter;
+        if (converter is null) {
+            return;
+        }
+
+        var tab = new NodeFormatTab(
+            new Node(converter.Type.Name),
+            NodeFormatKind.Unknown,
+            new DecompileViewModel(converter.Type));
+
+        FormatViewTabs.Add(tab);
+        SelectedTab = tab;
+    }
+
+    private bool CanOpenDecompiledConverter() =>
+        SelectedConverter is { Kind: TreeGridConverterKind.Converter };
+
 
     [RelayCommand(CanExecute = nameof(CanOpenAsObject))]
     private void OpenAsObject()

--- a/src/SceneGate.UI/SceneGate.UI.csproj
+++ b/src/SceneGate.UI/SceneGate.UI.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="bodong.Avalonia.PropertyGrid" />
     <PackageReference Include="bodong.PropertyModels" />
+    <PackageReference Include="ICSharpCode.Decompiler" />
 
     <PackageReference Include="Yarhl" />
     <PackageReference Include="Yarhl.Plugins" />

--- a/src/SceneGate.UI/Styling/ControlsStyle.axaml
+++ b/src/SceneGate.UI/Styling/ControlsStyle.axaml
@@ -3,19 +3,26 @@
         xmlns:ui="using:FluentAvalonia.UI.Controls"
         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives"
         xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
+        xmlns:aedit="using:AvaloniaEdit"
+        xmlns:aedit2="using:AvaloniaEdit.Editing"
         xmlns:cd="using:SceneGate.UI.ControlsData">
 
   <Design.PreviewWith>
     <Border Padding="30" MinWidth="350" Height="500">
-      <ScrollViewer>
-        <pgc:PropertyGrid Classes="ReadOnly Simple">
-          <pgc:PropertyGrid.SelectedObject>
-            <TextBox/>
-          </pgc:PropertyGrid.SelectedObject>
-        </pgc:PropertyGrid>
-      </ScrollViewer>
+      <aedit:TextEditor Text="Test" />
     </Border>
   </Design.PreviewWith>
+
+  <!-- set the selection color for the AvaloniaEdit boxes -->
+  <Style Selector="aedit2|TextArea">
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="SelectionForeground" Value="{DynamicResource TextOnAccentFillColorSelectedTextBrush}" />
+  </Style>
+
+  <!-- Adjust the ScrollViewer padding in AvaloniaEdit so scrollbar doesn't overlap text -->
+  <Style Selector="aedit|TextEditor /template/ ScrollViewer ScrollContentPresenter">
+    <Setter Property="Padding" Value="0 0 0 20" />
+  </Style>
 
   <!-- Simple and readonly styles for propertygrid -->
   <Style Selector="pgc|PropertyGrid.Simple">


### PR DESCRIPTION
New page to view the decompiled source code of a converter. It can help to quickly inspect for issues after trying on a format. It provides additional assembly info like path, website, version and copyright.

We are not displaying anything else that can be seen already with tools like ILSpy.

Also a couple of small fixes:
- Potential crash at startup loading converters
- Converter list may have not shown all the converters
- Upgrade pokemon conquest plugin

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] ~Related documentation is updated~
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- It's possible to see the source code of a converter.
- It shows the copright and authors of the code.

## Follow-up work

Refactor how we open tabs and all that code from AnalyzeViewModel

## Example

![image](https://github.com/SceneGate/SceneGate/assets/3107481/6188ccba-62ef-467c-a60f-e64b21c144b9)

